### PR TITLE
Fix broken Travis CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JAC Digital Platform
 
-[![Build Status](https://travis-ci.org/JudicialAppointmentsCommission/application-form.svg?branch=master)](https://travis-ci.org/JudicialAppointmentsCommission/application-form)
+[![Build Status](https://travis-ci.org/jac-uk/digital-platform.svg?branch=master)](https://travis-ci.org/jac-uk/digital-platform)
 
 This project contains components of the JAC Digital Platform which are concerned with handling user applications for 
 vacancies.


### PR DESCRIPTION
The Travis CI build status badge broke when we renamed our GitHub organisation and repository.