### PR TITLE
Fix broken Travis deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ after_success:
   - test $TRAVIS_BRANCH = "master" &&
     test $TRAVIS_PULL_REQUEST = "false" &&
     npm install -g firebase-tools &&
-    firebase deploy --token $FIREBASE_TOKEN --project default --force
+    firebase deploy --token $FIREBASE_TOKEN --project production --force


### PR DESCRIPTION
Travis CI was configured to deploy to the `default` project, which no longer exists. I've changed the Travis configuration to deploy to `production`.