### PR TITLE
Use Vue recommended linter rules

### DIFF
--- a/hosting/apply/.eslintrc
+++ b/hosting/apply/.eslintrc
@@ -5,18 +5,18 @@
     "jest": true
   },
   "extends": [
-    "plugin:vue/essential",
+    "plugin:vue/recommended",
     "eslint:recommended"
   ],
   "rules": {
-    "comma-dangle": ["error", {
-      "objects": "always"
-    }],
-    "semi": "error",
+    "comma-dangle": ["error", {"arrays": "always-multiline", "objects": "always-multiline"}],
+    "eol-last": ["error", "always"],
     "func-style": ["error", "expression"],
     "prefer-arrow-callback": "error",
-    "quotes": ["error", "single", { "avoidEscape": true}],
-    "eol-last": ["error", "always"]
+    "quotes": ["error", "single", {"avoidEscape": true}],
+    "semi": "error",
+    "vue/component-name-in-template-casing": "error",
+    "vue/script-indent": ["error", 2]
   },
   "parserOptions": {
     "parser": "babel-eslint"

--- a/hosting/apply/babel.config.js
+++ b/hosting/apply/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   presets: [
-    '@vue/app'
+    '@vue/app',
   ],
 };

--- a/hosting/apply/jest.config.js
+++ b/hosting/apply/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
     'js',
     'jsx',
     'json',
-    'vue'
+    'vue',
   ],
   transform: {
     '^.+\\.vue$': 'vue-jest',
@@ -14,18 +14,18 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   snapshotSerializers: [
-    'jest-serializer-vue'
+    'jest-serializer-vue',
   ],
   testMatch: [
-    '**/tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)'
+    '**/tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)',
   ],
   testURL: 'http://localhost/',
   collectCoverage: true,
   collectCoverageFrom: [
-    'src/**/*.{js,vue}'
+    'src/**/*.{js,vue}',
   ],
   coverageReporters: [
     'html',
-    'text-summary'
+    'text-summary',
   ],
 };

--- a/hosting/apply/src/App.vue
+++ b/hosting/apply/src/App.vue
@@ -1,17 +1,41 @@
 <template>
-  <div id="app" class="mb-5">
-    <nav class="navbar navbar-expand-sm navbar-light bg-light mb-4" v-if="isSignedIn">
+  <div
+    id="app"
+    class="mb-5"
+  >
+    <nav
+      v-if="isSignedIn"
+      class="navbar navbar-expand-sm navbar-light bg-light mb-4"
+    >
       <div class="container">
-        <RouterLink to="/" class="navbar-brand">
-          <img src="@/assets/jac-logo.svg" alt="Judicial Appointments Commission" width="197" height="66">
+        <RouterLink
+          to="/"
+          class="navbar-brand"
+        >
+          <img
+            src="@/assets/jac-logo.svg"
+            alt="Judicial Appointments Commission"
+            width="197"
+            height="66"
+          >
         </RouterLink>
         <div class="navbar-collapse">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item active">
-              <RouterLink to="/apply" class="nav-link" active-class="active">Apply</RouterLink>
+              <RouterLink
+                to="/apply"
+                class="nav-link"
+                active-class="active"
+              >
+                Apply
+              </RouterLink>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="#" @click.prevent="signOut">Sign out</a>
+              <a
+                class="nav-link"
+                href="#"
+                @click.prevent="signOut"
+              >Sign out</a>
             </li>
           </ul>
         </div>
@@ -23,28 +47,28 @@
 </template>
 
 <script>
-  import { mapGetters } from 'vuex';
-  import {auth} from '@/firebase';
+import { mapGetters } from 'vuex';
+import {auth} from '@/firebase';
 
-  export default {
-    methods: {
-      signOut() {
-        auth().signOut();
-      },
+export default {
+  methods: {
+    signOut() {
+      auth().signOut();
     },
-    computed: {
-      ...mapGetters([
-        'isSignedIn'
-      ]),
+  },
+  computed: {
+    ...mapGetters([
+      'isSignedIn',
+    ]),
+  },
+  watch: {
+    isSignedIn(signedIn) {
+      if (signedIn === false) {
+        this.$router.push({name: 'sign-in'});
+      }
     },
-    watch: {
-      isSignedIn(signedIn) {
-        if (signedIn === false) {
-          this.$router.push({name: 'sign-in',});
-        }
-      },
-    },
-  };
+  },
+};
 </script>
 
 <style lang="scss">

--- a/hosting/apply/src/App.vue
+++ b/hosting/apply/src/App.vue
@@ -51,11 +51,6 @@ import { mapGetters } from 'vuex';
 import {auth} from '@/firebase';
 
 export default {
-  methods: {
-    signOut() {
-      auth().signOut();
-    },
-  },
   computed: {
     ...mapGetters([
       'isSignedIn',
@@ -66,6 +61,11 @@ export default {
       if (signedIn === false) {
         this.$router.push({name: 'sign-in'});
       }
+    },
+  },
+  methods: {
+    signOut() {
+      auth().signOut();
     },
   },
 };

--- a/hosting/apply/src/components/ApplicationNav.vue
+++ b/hosting/apply/src/components/ApplicationNav.vue
@@ -1,19 +1,28 @@
 <template>
   <ol class="nav nav-pills flex-column">
-    <li v-for="page in applyPages" :key="page.path" class="nav-item">
-      <RouterLink :to="page.path" class="nav-link" active-class="active" exact>
-        {{page.title}}
+    <li
+      v-for="page in applyPages"
+      :key="page.path"
+      class="nav-item"
+    >
+      <RouterLink
+        :to="page.path"
+        class="nav-link"
+        active-class="active"
+        exact
+      >
+        {{ page.title }}
       </RouterLink>
     </li>
   </ol>
 </template>
 
 <script>
-  export default {
-    data() {
-      return {
-        applyPages: this.$store.getters.applyPages,
-      };
-    },
-  };
+export default {
+  data() {
+    return {
+      applyPages: this.$store.getters.applyPages,
+    };
+  },
+};
 </script>

--- a/hosting/apply/src/components/Banner.vue
+++ b/hosting/apply/src/components/Banner.vue
@@ -1,15 +1,21 @@
 <template>
   <div class="row mb-3">
     <div class="col">
-    <a href="https://docs.google.com/forms/d/1Q28Fdndoikn0PM7GrH1xt6qFf_t00dSaH-BGqmoTfT8/edit"
-      class="alpha btn btn-primary btn-sm font-weight-bold mr-1" target="_blank">
-      ALPHA
-    </a>
-    This is a new service – your
-    <a href="https://docs.google.com/forms/d/1Q28Fdndoikn0PM7GrH1xt6qFf_t00dSaH-BGqmoTfT8/edit" target="_blank">feedback</a>
-    will help us to improve it.
+      <a
+        href="https://docs.google.com/forms/d/1Q28Fdndoikn0PM7GrH1xt6qFf_t00dSaH-BGqmoTfT8/edit"
+        class="alpha btn btn-primary btn-sm font-weight-bold mr-1"
+        target="_blank"
+      >
+        ALPHA
+      </a>
+      This is a new service – your
+      <a
+        href="https://docs.google.com/forms/d/1Q28Fdndoikn0PM7GrH1xt6qFf_t00dSaH-BGqmoTfT8/edit"
+        target="_blank"
+      >feedback</a>
+      will help us to improve it.
+    </div>
   </div>
-</div>
 </template>
 
 <style scoped>

--- a/hosting/apply/src/components/BooleanInput.vue
+++ b/hosting/apply/src/components/BooleanInput.vue
@@ -1,44 +1,62 @@
 <template>
   <div>
     <div class="custom-control custom-radio custom-control-inline">
-      <input class="custom-control-input" type="radio" :id="yesInputId" :value="true" v-model="inputValue">
-      <label class="custom-control-label" :for="yesInputId">Yes</label>
+      <input
+        :id="yesInputId"
+        v-model="inputValue"
+        class="custom-control-input"
+        type="radio"
+        :value="true"
+      >
+      <label
+        class="custom-control-label"
+        :for="yesInputId"
+      >Yes</label>
     </div>
     <div class="custom-control custom-radio custom-control-inline">
-      <input class="custom-control-input" type="radio" :id="noInputId" :value="false" v-model="inputValue">
-      <label class="custom-control-label" :for="noInputId">No</label>
+      <input
+        :id="noInputId"
+        v-model="inputValue"
+        class="custom-control-input"
+        type="radio"
+        :value="false"
+      >
+      <label
+        class="custom-control-label"
+        :for="noInputId"
+      >No</label>
     </div>
   </div>
 </template>
 
 <script>
-  let uid = 0;
+let uid = 0;
 
-  export default {
-    name: 'BooleanInput',
-    props: {
-      value: {
-        required: true,
+export default {
+  name: 'BooleanInput',
+  props: {
+    value: {
+      required: true,
+    },
+  },
+  data() {
+    return {
+      yesInputId: `boolean_${uid}_yes`,
+      noInputId: `boolean_${uid}_no`,
+    };
+  },
+  computed: {
+    inputValue: {
+      get() {
+        return this.value;
+      },
+      set(value) {
+        this.$emit('input', value);
       },
     },
-    data() {
-      return {
-        yesInputId: `boolean_${uid}_yes`,
-        noInputId: `boolean_${uid}_no`,
-      };
-    },
-    computed: {
-      inputValue: {
-        get() {
-          return this.value;
-        },
-        set(value) {
-          this.$emit('input', value);
-        },
-      },
-    },
-    created() {
-      uid++;
-    },
-  };
+  },
+  created() {
+    uid++;
+  },
+};
 </script>

--- a/hosting/apply/src/components/BooleanInput.vue
+++ b/hosting/apply/src/components/BooleanInput.vue
@@ -37,6 +37,7 @@ export default {
   props: {
     value: {
       required: true,
+      validator: (value) => ([true, false, null, undefined].indexOf(value) !== -1),
     },
   },
   data() {

--- a/hosting/apply/src/components/DateInput.vue
+++ b/hosting/apply/src/components/DateInput.vue
@@ -1,158 +1,179 @@
 <template>
   <div class="date-input form-row mb-3">
-    <div class="col-3" v-if="type === 'date'">
+    <div
+      v-if="type === 'date'"
+      class="col-3"
+    >
       <label :for="dayInputId">Day</label>
-      <input type="tel" class="form-control" :id="dayInputId" v-model.lazy="dayInput" ref="dayInput">
+      <input
+        :id="dayInputId"
+        ref="dayInput"
+        v-model.lazy="dayInput"
+        type="tel"
+        class="form-control"
+      >
     </div>
     <div class="col-3">
       <label :for="monthInputId">Month</label>
-      <input type="tel" class="form-control" :id="monthInputId" v-model.lazy="monthInput" ref="monthInput">
+      <input
+        :id="monthInputId"
+        ref="monthInput"
+        v-model.lazy="monthInput"
+        type="tel"
+        class="form-control"
+      >
     </div>
     <div class="col-6">
       <label :for="yearInputId">Year</label>
-      <input type="tel" class="form-control" :id="yearInputId" v-model.lazy="yearInput" ref="yearInput">
+      <input
+        :id="yearInputId"
+        ref="yearInput"
+        v-model.lazy="yearInput"
+        type="tel"
+        class="form-control"
+      >
     </div>
   </div>
 </template>
 
 <script>
-  let uid = 0;
+let uid = 0;
 
-  export default {
-    name: 'DateInput',
-    props: {
-      value: {
-        required: true,
-        validator: (value) => (value instanceof Date || value === null || value === undefined),
+export default {
+  name: 'DateInput',
+  props: {
+    value: {
+      required: true,
+      validator: (value) => (value instanceof Date || value === null || value === undefined),
+    },
+    type: {
+      default: 'date',
+      validator: (value) => (['date', 'month'].indexOf(value) !== -1),
+    },
+  },
+  data() {
+    return {
+      day: null,
+      month: null,
+      year: null,
+      dayInputId: `date_${uid}_day`,
+      monthInputId: `date_${uid}_month`,
+      yearInputId: `date_${uid}_year`,
+    };
+  },
+  computed: {
+    dayInput: {
+      get() {
+        if (this.day === null) return null;
+        // Zero-pad number as a string
+        return this.zeroPad(this.day);
       },
-      type: {
-        default: 'date',
-        validator: (value) => (['date', 'month'].indexOf(value) !== -1),
+      set(value) {
+        let int = parseInt(value);
+
+        if (isNaN(int)) {
+          this.day = null;
+          return;
+        }
+
+        // Enforce lower & upper bounds
+        if (int < 1) int = 1;
+        if (int > 31) int = 31;
+        this.day = int;
       },
     },
-    data() {
-      return {
-        day: null,
-        month: null,
-        year: null,
-        dayInputId: `date_${uid}_day`,
-        monthInputId: `date_${uid}_month`,
-        yearInputId: `date_${uid}_year`,
-      };
+    monthInput: {
+      get() {
+        if (this.month === null) return null;
+        // Zero-pad number as a string
+        return this.zeroPad(this.month);
+      },
+      set(value) {
+        let int = parseInt(value);
+
+        if (isNaN(int)) {
+          this.month = null;
+          return;
+        }
+
+        // Enforce lower & upper bounds
+        if (int < 1) int = 1;
+        if (int > 12) int = 12;
+        this.month = int;
+      },
     },
-    computed: {
-      dayInput: {
-        get() {
-          if (this.day === null) return null;
-          // Zero-pad number as a string
-          return this.zeroPad(this.day);
-        },
-        set(value) {
-          let int = parseInt(value);
-
-          if (isNaN(int)) {
-            this.day = null;
-            return;
-          }
-
-          // Enforce lower & upper bounds
-          if (int < 1) int = 1;
-          if (int > 31) int = 31;
-          this.day = int;
-        },
+    yearInput: {
+      get() {
+        return this.year;
       },
-      monthInput: {
-        get() {
-          if (this.month === null) return null;
-          // Zero-pad number as a string
-          return this.zeroPad(this.month);
-        },
-        set(value) {
-          let int = parseInt(value);
+      set(value) {
+        let int = parseInt(value);
 
-          if (isNaN(int)) {
-            this.month = null;
-            return;
-          }
+        if (isNaN(int)) {
+          this.year = null;
+          return;
+        }
 
-          // Enforce lower & upper bounds
-          if (int < 1) int = 1;
-          if (int > 12) int = 12;
-          this.month = int;
-        },
+        this.year = int;
       },
-      yearInput: {
-        get() {
-          return this.year;
-        },
-        set(value) {
-          let int = parseInt(value);
+    },
+    dateConstructor() {
+      const day = this.day;
+      const month = this.month;
+      const year = this.year;
 
-          if (isNaN(int)) {
-            this.year = null;
-            return;
-          }
-
-          this.year = int;
-        },
-      },
-      dateConstructor() {
-        const day = this.day;
-        const month = this.month;
-        const year = this.year;
-
-        if (this.type === 'month' && month && year) {
-          return [year, month-1];
-        } else if (day && month && year) {
-          return [year, month-1, day];
-        } else {
+      if (this.type === 'month' && month && year) {
+        return [year, month-1];
+      } else if (day && month && year) {
+        return [year, month-1, day];
+      } else {
+        return null;
+      }
+    },
+    date: {
+      get() {
+        if (this.dateConstructor === null) {
           return null;
+        } else {
+          return new Date(Date.UTC(...this.dateConstructor));
         }
       },
-      date: {
-        get() {
-          if (this.dateConstructor === null) {
-            return null;
-          } else {
-            return new Date(Date.UTC(...this.dateConstructor));
-          }
-        },
-        set(value) {
-          if (value instanceof Date) {
-            this.day = value.getUTCDate();
-            this.month = value.getUTCMonth() + 1;
-            this.year = value.getUTCFullYear();
-          }
-        },
-      },
-    },
-    methods: {
-      zeroPad(number) {
-        return number.toString().padStart(2, '0');
-      },
-      datesAreEqual(date1, date2) {
-        return (
-          date1 instanceof Date &&
-          date2 instanceof Date &&
-          date1.getTime() === date2.getTime()
-        );
-      },
-    },
-    watch: {
-      value(newValue, oldValue) {
-        if (!this.datesAreEqual(newValue, oldValue)) {
-          this.date = newValue;
+      set(value) {
+        if (value instanceof Date) {
+          this.day = value.getUTCDate();
+          this.month = value.getUTCMonth() + 1;
+          this.year = value.getUTCFullYear();
         }
       },
-      date(value) {
-        this.$emit('input', value);
-      },
     },
-    created() {
-      this.date = this.value;
-      uid++;
+  },
+  watch: {
+    value(newValue, oldValue) {
+      if (!this.datesAreEqual(newValue, oldValue)) {
+        this.date = newValue;
+      }
     },
-  };
+    date(value) {
+      this.$emit('input', value);
+    },
+  },
+  created() {
+    this.date = this.value;
+    uid++;
+  },
+  methods: {
+    zeroPad(number) {
+      return number.toString().padStart(2, '0');
+    },
+    datesAreEqual(date1, date2) {
+      return (
+        date1 instanceof Date &&
+        date2 instanceof Date &&
+        date1.getTime() === date2.getTime()
+      );
+    },
+  },
+};
 </script>
 
 <style scoped>

--- a/hosting/apply/src/components/FirebaseUI.vue
+++ b/hosting/apply/src/components/FirebaseUI.vue
@@ -1,44 +1,44 @@
 <template>
-  <div id="firebaseui-auth-container"></div>
+  <div id="firebaseui-auth-container" />
 </template>
 
 <script>
-  import {auth} from '@/firebase';
-  import firebaseui from 'firebaseui';
+import {auth} from '@/firebase';
+import firebaseui from 'firebaseui';
 
-  export default {
-    name: 'FirebaseUI',
-    mounted() {
-      this.ui = new firebaseui.auth.AuthUI(auth());
-      this.ui.start('#firebaseui-auth-container', this.uiConfig);
-    },
-    destroyed() {
-      this.ui.delete();
-    },
-    data() {
-      return {
-        uiConfig: {
-          signInOptions: [
-            {
-              provider: auth.EmailAuthProvider.PROVIDER_ID,
-              requireDisplayName: false,
-            }
-          ],
-          credentialHelper: firebaseui.auth.CredentialHelper.NONE,
-          callbacks: {
-            signInSuccessWithAuthResult: this.signInSuccess,
+export default {
+  name: 'FirebaseUI',
+  data() {
+    return {
+      uiConfig: {
+        signInOptions: [
+          {
+            provider: auth.EmailAuthProvider.PROVIDER_ID,
+            requireDisplayName: false,
           },
+        ],
+        credentialHelper: firebaseui.auth.CredentialHelper.NONE,
+        callbacks: {
+          signInSuccessWithAuthResult: this.signInSuccess,
         },
-      };
-    },
-    methods: {
-      signInSuccess(authResult) {
-          this.$emit('signInSuccess', authResult);
-        // Return false to disable FirebaseUI auth redirect
-        return false;
       },
+    };
+  },
+  mounted() {
+    this.ui = new firebaseui.auth.AuthUI(auth());
+    this.ui.start('#firebaseui-auth-container', this.uiConfig);
+  },
+  destroyed() {
+    this.ui.delete();
+  },
+  methods: {
+    signInSuccess(authResult) {
+      this.$emit('signInSuccess', authResult);
+      // Return false to disable FirebaseUI auth redirect
+      return false;
     },
-  };
+  },
+};
 </script>
 
 <style src="firebaseui/dist/firebaseui.css"></style>

--- a/hosting/apply/src/components/RepeatableFields.vue
+++ b/hosting/apply/src/components/RepeatableFields.vue
@@ -45,6 +45,7 @@ export default {
     },
     component: {
       required: true,
+      type: Object,
     },
     max: {
       required: false,

--- a/hosting/apply/src/components/RepeatableFields.vue
+++ b/hosting/apply/src/components/RepeatableFields.vue
@@ -1,16 +1,34 @@
 <template>
   <div>
-    <div class="card mb-3" v-for="(row, index) in rows" :key="index">
-      <component class="card-body" :row="row" :index="index" :is="component">
+    <div
+      v-for="(row, index) in rows"
+      :key="index"
+      class="card mb-3"
+    >
+      <component
+        :is="component"
+        class="card-body"
+        :row="row"
+        :index="index"
+      >
         <template slot="removeButton">
-          <button @click.prevent="removeRow(index)" class="btn btn-secondary" type="button">
+          <button
+            class="btn btn-secondary"
+            type="button"
+            @click.prevent="removeRow(index)"
+          >
             Remove
           </button>
         </template>
       </component>
     </div>
     <div class="text-right">
-      <button @click.prevent="addRow" class="btn btn-primary" type="button" v-if="canAddRow">
+      <button
+        v-if="canAddRow"
+        class="btn btn-primary"
+        type="button"
+        @click.prevent="addRow"
+      >
         Add another
       </button>
     </div>
@@ -18,56 +36,56 @@
 </template>
 
 <script>
-  export default {
-    name: 'RepeatableFields',
-    props: {
-      value: {
-        validator: (value) => (value instanceof Array || value === null || value === undefined),
-        required: true,
-      },
-      component: {
-        required: true,
-      },
-      max: {
-        required: false,
-        default: false,
-        type: [Number, Boolean],
-      },
+export default {
+  name: 'RepeatableFields',
+  props: {
+    value: {
+      validator: (value) => (value instanceof Array || value === null || value === undefined),
+      required: true,
     },
-    data() {
-      return {
-        rows: [],
-      };
+    component: {
+      required: true,
     },
-    computed: {
-      canAddRow() {
-        if (this.max) {
-          return this.rows.length < this.max;
-        } else {
-          return true;
-        }
-      },
+    max: {
+      required: false,
+      default: false,
+      type: [Number, Boolean],
     },
-    methods: {
-      addRow() {
-        if (this.canAddRow) {
-          this.rows.push({});
-        }
-      },
-      removeRow(index) {
-        this.rows.splice(index, 1);
-      },
-    },
-    created() {
-      if (this.value instanceof Array) {
-        this.rows = this.value;
+  },
+  data() {
+    return {
+      rows: [],
+    };
+  },
+  computed: {
+    canAddRow() {
+      if (this.max) {
+        return this.rows.length < this.max;
       } else {
-        this.$emit('input', this.rows);
-      }
-
-      if (this.rows.length === 0) {
-        this.addRow();
+        return true;
       }
     },
-  };
+  },
+  created() {
+    if (this.value instanceof Array) {
+      this.rows = this.value;
+    } else {
+      this.$emit('input', this.rows);
+    }
+
+    if (this.rows.length === 0) {
+      this.addRow();
+    }
+  },
+  methods: {
+    addRow() {
+      if (this.canAddRow) {
+        this.rows.push({});
+      }
+    },
+    removeRow(index) {
+      this.rows.splice(index, 1);
+    },
+  },
+};
 </script>

--- a/hosting/apply/src/components/Review/BooleanWithCheckboxes.vue
+++ b/hosting/apply/src/components/Review/BooleanWithCheckboxes.vue
@@ -76,13 +76,34 @@
 <script>
 export default {
   props: {
-    answeredYes: Boolean,
-    changeLink: String,
-    records: Array,
-    subtitle: String,
-    title: String,
-    otherCaption: String,
-    other: String,
+    answeredYes: {
+      type: Boolean,
+      required: true,
+    },
+    changeLink: {
+      type: String,
+      required: true,
+    },
+    records: {
+      type: Array,
+      required: true,
+    },
+    subtitle: {
+      type: String,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+    otherCaption: {
+      type: String,
+      required: true,
+    },
+    other: {
+      type: String,
+      required: true,
+    },
   },
 };
 </script>

--- a/hosting/apply/src/components/Review/BooleanWithCheckboxes.vue
+++ b/hosting/apply/src/components/Review/BooleanWithCheckboxes.vue
@@ -1,13 +1,16 @@
 <template>
   <article>
-    <table class="table" v-if="answeredYes">
+    <table
+      v-if="answeredYes"
+      class="table"
+    >
       <tbody>
         <tr>
           <th>
             {{ title }}
           </th>
           <td class="p-3 text-right">
-             Yes
+            Yes
           </td>
         </tr>
         <tr>
@@ -15,8 +18,13 @@
             {{ subtitle }}
           </th>
         </tr>
-        <tr v-for="record in records" :key="record">
-          <td colspan="2">{{ record }}</td>
+        <tr
+          v-for="record in records"
+          :key="record"
+        >
+          <td colspan="2">
+            {{ record }}
+          </td>
         </tr>
         <tr v-if="other">
           <th v-if="otherCaption">
@@ -28,13 +36,21 @@
         </tr>
         <tr>
           <td colspan="10">
-            <RouterLink :to="changeLink" class="float-right">Change</RouterLink>
+            <RouterLink
+              :to="changeLink"
+              class="float-right"
+            >
+              Change
+            </RouterLink>
           </td>
         </tr>
       </tbody>
     </table>
 
-    <table class="table" v-else>
+    <table
+      v-else
+      class="table"
+    >
       <tbody>
         <tr>
           <th class="boolean_no">
@@ -44,7 +60,12 @@
             No
           </td>
           <td class="p-3 text-right">
-            <RouterLink :to="changeLink" class="float-right">Change</RouterLink>
+            <RouterLink
+              :to="changeLink"
+              class="float-right"
+            >
+              Change
+            </RouterLink>
           </td>
         </tr>
       </tbody>

--- a/hosting/apply/src/components/Review/CharacterTable.vue
+++ b/hosting/apply/src/components/Review/CharacterTable.vue
@@ -1,6 +1,9 @@
 <template>
   <article>
-    <table class="table" v-if="answeredYes">
+    <table
+      v-if="answeredYes"
+      class="table"
+    >
       <thead>
         <tr>
           <th colspan="10">
@@ -8,21 +11,47 @@
           </th>
         </tr>
       </thead>
-      <tbody v-for="record in visibleRecords" :key="record.id">
-        <tr v-for="(value, key) in record" :key="value.id">
-          <th class="text-capitalize offence_key">{{ key.replace('_', ' ') }}</th>
-          <td v-if="value instanceof Date" class="offence_info">{{ value.toLocaleDateString("en-GB", { month: "numeric", year: "numeric" }) }}</td>
-          <td v-else class="offence_info">{{ value }}</td>
+      <tbody
+        v-for="record in visibleRecords"
+        :key="record.id"
+      >
+        <tr
+          v-for="(value, key) in record"
+          :key="value.id"
+        >
+          <th class="text-capitalize offence_key">
+            {{ key.replace('_', ' ') }}
+          </th>
+          <td
+            v-if="value instanceof Date"
+            class="offence_info"
+          >
+            {{ value.toLocaleDateString("en-GB", { month: "numeric", year: "numeric" }) }}
+          </td>
+          <td
+            v-else
+            class="offence_info"
+          >
+            {{ value }}
+          </td>
         </tr>
         <tr>
           <td colspan="10">
-            <RouterLink to="/apply/character" class="float-right">Change</RouterLink>
+            <RouterLink
+              to="/apply/character"
+              class="float-right"
+            >
+              Change
+            </RouterLink>
           </td>
         </tr>
       </tbody>
     </table>
 
-    <table class="table" v-else>
+    <table
+      v-else
+      class="table"
+    >
       <tbody>
         <tr>
           <th class="boolean_no">
@@ -32,7 +61,12 @@
             No
           </td>
           <td class="p-3 text-right">
-            <RouterLink to="/apply/character" class="float-right">Change</RouterLink>
+            <RouterLink
+              to="/apply/character"
+              class="float-right"
+            >
+              Change
+            </RouterLink>
           </td>
         </tr>
       </tbody>

--- a/hosting/apply/src/components/Review/CharacterTable.vue
+++ b/hosting/apply/src/components/Review/CharacterTable.vue
@@ -77,9 +77,18 @@
 <script>
 export default {
   props: {
-    answeredYes: Boolean,
-    records: Array,
-    title: String,
+    answeredYes: {
+      type: Boolean,
+      required: true,
+    },
+    records: {
+      type: Array,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
   },
   computed: {
     visibleRecords: function () {

--- a/hosting/apply/src/components/SaveAndContinueButtons.vue
+++ b/hosting/apply/src/components/SaveAndContinueButtons.vue
@@ -1,24 +1,36 @@
 <template>
   <div class="form-actions">
-    <button class="btn btn-outline-secondary mr-2" :disabled="isSaving" type="submit">
+    <button
+      class="btn btn-outline-secondary mr-2"
+      :disabled="isSaving"
+      type="submit"
+    >
       Save
     </button>
-    <button class="btn btn-primary mr-2" type="button" :disabled="isSaving" @click.prevent="$emit('saveAndContinue')">
+    <button
+      class="btn btn-primary mr-2"
+      type="button"
+      :disabled="isSaving"
+      @click.prevent="$emit('saveAndContinue')"
+    >
       Save and continue
     </button>
-    <span class="spinner-border spinner-border-sm text-secondary" v-if="isSaving"></span>
+    <span
+      v-if="isSaving"
+      class="spinner-border spinner-border-sm text-secondary"
+    />
   </div>
 </template>
 
 <script>
-  export default {
-    props: {
-      isSaving: {
-        type: Boolean,
-        required: true,
-      },
+export default {
+  props: {
+    isSaving: {
+      type: Boolean,
+      required: true,
     },
-  };
+  },
+};
 </script>
 
 <style scoped>

--- a/hosting/apply/src/components/SelectList.vue
+++ b/hosting/apply/src/components/SelectList.vue
@@ -1,92 +1,113 @@
 <template>
   <div>
-    <div :class="divClass" v-for="(option, index) in inputOptions" :key="option.value">
+    <div
+      v-for="(option, index) in inputOptions"
+      :key="option.value"
+      :class="divClass"
+    >
       <!--
         Dynamic `type` attributes don't work in IE11, so here we conditionally show/hide a radio or checkbox
         depending on the value of the `type` computed property.
 
         Related to: https://github.com/vuejs/vue/issues/8379
       -->
-      <input v-if="type === 'radio'" type="radio" class="custom-control-input" :id="id + '_' + index" :value="option.value" v-model="inputValue">
-      <input v-if="type === 'checkbox'" type="checkbox" class="custom-control-input" :id="id + '_' + index" :value="option.value" v-model="inputValue">
+      <input
+        v-if="type === 'radio'"
+        :id="id + '_' + index"
+        v-model="inputValue"
+        type="radio"
+        class="custom-control-input"
+        :value="option.value"
+      >
+      <input
+        v-if="type === 'checkbox'"
+        :id="id + '_' + index"
+        v-model="inputValue"
+        type="checkbox"
+        class="custom-control-input"
+        :value="option.value"
+      >
 
-      <label class="custom-control-label" :for="id + '_' + index">
-        {{option.label}}
+      <label
+        class="custom-control-label"
+        :for="id + '_' + index"
+      >
+        {{ option.label }}
       </label>
     </div>
   </div>
 </template>
 
 <script>
-  export default {
-    name: 'SelectList',
-    props: {
-      id: {
-        type: String,
-        required: true,
+export default {
+  name: 'SelectList',
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+    options: {
+      type: Array,
+      required: true,
+    },
+    multiple: {
+      type: Boolean,
+      default: false,
+    },
+    value: {
+      required: true,
+    },
+  },
+  data() {
+    return {};
+  },
+  computed: {
+    type() {
+      return this.multiple ? 'checkbox' : 'radio';
+    },
+    divClass() {
+      return [
+        'custom-control',
+        'custom-' + this.type,
+      ];
+    },
+    inputValue: {
+      get() {
+        return this.value;
       },
-      options: {
-        type: Array,
-        required: true,
-      },
-      multiple: {
-        type: Boolean,
-        default: false,
-      },
-      value: {
-        required: true,
+      set(value) {
+        this.$emit('input', value);
       },
     },
-    data() {
-      return {};
-    },
-    methods: {
-      makeValueAnArrayIfMultiple() {
-        if (this.multiple && !(this.value instanceof Array)) {
-          this.inputValue = [];
+    inputOptions() {
+      return this.options.map(option => {
+        if (typeof option === 'string') {
+          return {
+            value: option,
+            label: option,
+          };
         }
-      },
+        return option;
+      });
     },
-    computed: {
-      type() {
-        return this.multiple ? 'checkbox' : 'radio';
-      },
-      divClass() {
-        return [
-          'custom-control',
-          'custom-' + this.type
-        ];
-      },
-      inputValue: {
-        get() {
-          return this.value;
-        },
-        set(value) {
-          this.$emit('input', value);
-        },
-      },
-      inputOptions() {
-        return this.options.map(option => {
-          if (typeof option === 'string') {
-            return {
-              value: option,
-              label: option,
-            };
-          }
-          return option;
-        });
-      },
-      multiAndValue() {
-        return [this.multiple, this.value];
-      },
+    multiAndValue() {
+      return [this.multiple, this.value];
     },
-    watch: {
-      multiAndValue() {
-        this.makeValueAnArrayIfMultiple();
-      },
-    },
-    created() {
+  },
+  watch: {
+    multiAndValue() {
       this.makeValueAnArrayIfMultiple();
     },
-  };
+  },
+  created() {
+    this.makeValueAnArrayIfMultiple();
+  },
+  methods: {
+    makeValueAnArrayIfMultiple() {
+      if (this.multiple && !(this.value instanceof Array)) {
+        this.inputValue = [];
+      }
+    },
+  },
+};
 </script>

--- a/hosting/apply/src/components/SelectList.vue
+++ b/hosting/apply/src/components/SelectList.vue
@@ -55,6 +55,7 @@ export default {
       default: false,
     },
     value: {
+      validator: (value) => (value instanceof Array || typeof value === 'string' || value === null || value === undefined),
       required: true,
     },
   },

--- a/hosting/apply/src/components/SelectList/Show.vue
+++ b/hosting/apply/src/components/SelectList/Show.vue
@@ -48,12 +48,30 @@
 <script>
 export default {
   props: {
-    changeLink: String,
-    hasOther: Boolean,
-    other: String,
-    records: Array,
-    singleResponse: String,
-    title: String,
+    changeLink: {
+      type: String,
+      required: true,
+    },
+    hasOther: {
+      type: Boolean,
+      required: true,
+    },
+    other: {
+      type: String,
+      required: true,
+    },
+    records: {
+      type: Array,
+      required: true,
+    },
+    singleResponse: {
+      type: String,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
   },
 };
 </script>

--- a/hosting/apply/src/components/SelectList/Show.vue
+++ b/hosting/apply/src/components/SelectList/Show.vue
@@ -2,7 +2,7 @@
   <article>
     <table class="table mb-3">
       <tr>
-        <th colspan=2>
+        <th colspan="2">
           {{ title }}
         </th>
       </tr>
@@ -10,24 +10,35 @@
         <td>
           {{ singleResponse }}
         </td>
-        <td v-if="singleResponse === 'Other'" class="float-right">
+        <td
+          v-if="singleResponse === 'Other'"
+          class="float-right"
+        >
           {{ other }}
         </td>
       </tr>
-      <tr v-for="record in records" :key="record">
-        <td colspan=2>
+      <tr
+        v-for="record in records"
+        :key="record"
+      >
+        <td colspan="2">
           {{ record }}
         </td>
       </tr>
       <tr v-if="hasOther">
-        <td colspan=2>
+        <td colspan="2">
           Other:&nbsp;
           {{ other }}
         </td>
       </tr>
       <tr>
-        <td colspan=2>
-          <RouterLink :to="changeLink" class="float-right">Change</RouterLink>
+        <td colspan="2">
+          <RouterLink
+            :to="changeLink"
+            class="float-right"
+          >
+            Change
+          </RouterLink>
         </td>
       </tr>
     </table>

--- a/hosting/apply/src/router.js
+++ b/hosting/apply/src/router.js
@@ -90,7 +90,7 @@ const router = new Router({
         {
           path: 'submitted',
           component: Submitted,
-        }
+        },
       ],
     },
     {
@@ -108,7 +108,7 @@ const router = new Router({
 
         if (!isSignedIn) {
           // User must be logged in
-          return next({name: 'sign-in',});
+          return next({name: 'sign-in'});
         }
 
         if (isEmailVerified) {
@@ -122,13 +122,13 @@ const router = new Router({
     {
       path: '*',
       redirect: '/apply',
-    }
+    },
   ],
   scrollBehavior(to, from, savedPosition) {
     if (savedPosition) {
       return savedPosition;
     } else {
-      return {x: 0, y: 0,};
+      return {x: 0, y: 0};
     }
   },
 });
@@ -147,12 +147,12 @@ router.beforeEach((to, from, next) => {
 
   if (requiresAuth && !isSignedIn) {
     // User must be logged in
-    return next({name: 'sign-in',});
+    return next({name: 'sign-in'});
   }
 
   if (requiresAuth && !isEmailVerified) {
     // User must verify their email address
-    return next({name: 'verify-email',});
+    return next({name: 'verify-email'});
   }
 
   return next();

--- a/hosting/apply/src/sentry.js
+++ b/hosting/apply/src/sentry.js
@@ -7,7 +7,7 @@ const initSentry = () => {
   Sentry.init({
     dsn: 'https://2366ef9baa1a49bb8aa29c5262757de9@sentry.io/1499367',
     environment: process.env.NODE_ENV,
-    integrations: [new Integrations.Vue({Vue, attachProps: true,})],
+    integrations: [new Integrations.Vue({Vue, attachProps: true})],
   });
   setUserScope();
 };

--- a/hosting/apply/src/store/applicant.js
+++ b/hosting/apply/src/store/applicant.js
@@ -12,7 +12,7 @@ const module = {
     },
   },
   actions: {
-    async loadApplicant({commit, getters,}) {
+    async loadApplicant({commit, getters}) {
       if (!getters.applicantDoc) {
         throw new Error('Cannot get Applicant doc (currentUserId is not set)');
       }
@@ -25,7 +25,7 @@ const module = {
         commit('setApplicant', {});
       }
     },
-    async saveApplicant({commit, getters,}, data) {
+    async saveApplicant({commit, getters}, data) {
       if (!getters.applicantDoc) {
         throw new Error('Cannot get Applicant doc (currentUserId is not set)');
       }

--- a/hosting/apply/src/store/application.js
+++ b/hosting/apply/src/store/application.js
@@ -8,13 +8,13 @@ const module = {
     id: null,
   },
   mutations: {
-    setApplication(state, {id, data,}) {
+    setApplication(state, {id, data}) {
       state.id = id;
       state.data = data;
     },
   },
   actions: {
-    async loadApplication({commit, getters,}) {
+    async loadApplication({commit, getters}) {
       if (!getters.applicantDoc || !getters.vacancyDoc) {
         throw new Error('Applicant and Vacancy docs must exist to load an Application');
       }
@@ -27,7 +27,7 @@ const module = {
         .get();
 
       if (results.empty) {
-        commit('setApplication', {id: null, data: { state: 'draft', createdAt: new Date, updatedAt: new Date,},});
+        commit('setApplication', {id: null, data: { state: 'draft', createdAt: new Date, updatedAt: new Date}});
       } else {
         const doc = results.docs[0];
 
@@ -37,10 +37,10 @@ const module = {
         data = sanitizeFirestore(data);
         data.updatedAt = new Date;
 
-        commit('setApplication', {id: doc.id, data,});
+        commit('setApplication', {id: doc.id, data});
       }
     },
-    async saveApplication({commit, getters,}, data) {
+    async saveApplication({commit, getters}, data) {
       if (!getters.applicantDoc || !getters.vacancyDoc) {
         throw new Error('Applicant and Vacancy docs must exist to save an Application');
       }
@@ -48,7 +48,7 @@ const module = {
       saveData.applicant = getters.applicantDoc;
       saveData.vacancy = getters.vacancyDoc;
       await getters.applicationDoc.set(saveData);
-      commit('setApplication', {id: getters.applicationDoc.id, data: clone(data),});
+      commit('setApplication', {id: getters.applicationDoc.id, data: clone(data)});
     },
   },
   getters: {

--- a/hosting/apply/src/store/auth.js
+++ b/hosting/apply/src/store/auth.js
@@ -8,7 +8,7 @@ const module = {
     },
   },
   actions: {
-    setCurrentUser({commit,}, user) {
+    setCurrentUser({commit}, user) {
       if (user === null) {
         commit('setCurrentUser', null);
       } else {

--- a/hosting/apply/src/store/navigation.js
+++ b/hosting/apply/src/store/navigation.js
@@ -56,7 +56,7 @@ const module = {
       {
         title: 'Submitted',
         path: '/apply/submitted',
-      }
+      },
     ],
     currentPage: undefined,
   },
@@ -66,7 +66,7 @@ const module = {
     },
   },
   actions: {
-    setCurrentPagePath({commit, state,}, path) {
+    setCurrentPagePath({commit, state}, path) {
       const currentPage = state.applyPages.find((page) => {
         return page.path === path;
       });

--- a/hosting/apply/src/store/vacancy.js
+++ b/hosting/apply/src/store/vacancy.js
@@ -15,7 +15,7 @@ const module = {
     },
   },
   actions: {
-    async loadVacancy({commit, state, getters,}) {
+    async loadVacancy({commit, state, getters}) {
       if (!state.id) {
         throw new Error('You must set the Vacancy ID first using the setVacancyId mutation');
       }

--- a/hosting/apply/src/views/Apply.vue
+++ b/hosting/apply/src/views/Apply.vue
@@ -22,54 +22,54 @@
 </template>
 
 <script>
-  import ApplicationNav from '@/components/ApplicationNav';
-  import Banner from '@/components/Banner';
+import ApplicationNav from '@/components/ApplicationNav';
+import Banner from '@/components/Banner';
 
-  export default {
-    name: 'Apply',
-    components: {
-      ApplicationNav,
-      Banner,
+export default {
+  name: 'Apply',
+  components: {
+    ApplicationNav,
+    Banner,
+  },
+  data() {
+    return {
+      vacancyId: 'hsQqdvAfZpSw94X2B8nA', // hardcoded for now
+      loaded: false,
+      loadFailed: false,
+    };
+  },
+  watch: {
+    '$route'(to) {
+      this.$store.dispatch('setCurrentPagePath', to.path);
     },
-    data() {
-      return {
-        vacancyId: 'hsQqdvAfZpSw94X2B8nA', // hardcoded for now
-        loaded: false,
-        loadFailed: false,
-      };
-    },
-    methods: {
-      initStore() {
-        this.$store.commit('setVacancyId', this.vacancyId);
-        return Promise.all([
-          this.$store.dispatch('loadApplicant'),
-          this.$store.dispatch('loadVacancy'),
-          this.$store.dispatch('loadApplication')
-        ]);
-      },
-      nextPage() {
-        const nextPage = this.$store.getters.nextPagePath;
-        if (nextPage) {
-          this.$router.push(nextPage);
-        }
-      },
-    },
-    created() {
-      this.initStore()
-        .then(() => {
-          this.loaded = true;
-        })
-        .catch((e) => {
-          this.loadFailed = true;
-          throw e;
-        });
+  },
+  created() {
+    this.initStore()
+      .then(() => {
+        this.loaded = true;
+      })
+      .catch((e) => {
+        this.loadFailed = true;
+        throw e;
+      });
 
-      this.$store.dispatch('setCurrentPagePath', this.$route.path);
+    this.$store.dispatch('setCurrentPagePath', this.$route.path);
+  },
+  methods: {
+    initStore() {
+      this.$store.commit('setVacancyId', this.vacancyId);
+      return Promise.all([
+        this.$store.dispatch('loadApplicant'),
+        this.$store.dispatch('loadVacancy'),
+        this.$store.dispatch('loadApplication'),
+      ]);
     },
-    watch: {
-      '$route'(to) {
-        this.$store.dispatch('setCurrentPagePath', to.path);
-      },
+    nextPage() {
+      const nextPage = this.$store.getters.nextPagePath;
+      if (nextPage) {
+        this.$router.push(nextPage);
+      }
     },
-  };
+  },
+};
 </script>

--- a/hosting/apply/src/views/RepeatableFields/Assessor.vue
+++ b/hosting/apply/src/views/RepeatableFields/Assessor.vue
@@ -2,60 +2,89 @@
   <div>
     <div class="form-group">
       <label>Is this assessor professional or judicial?</label>
-      <SelectList :options="selectListOptions.types" v-model="row.type" :id="inputIds.type" />
+      <SelectList
+        :id="inputIds.type"
+        v-model="row.type"
+        :options="selectListOptions.types"
+      />
     </div>
     <div class="form-group">
       <label :for="inputIds.relationship">What is the assessor’s relationship to you?</label>
-      <input class="form-control" type="text" :id="inputIds.relationship" v-model="row.relationship" />
+      <input
+        :id="inputIds.relationship"
+        v-model="row.relationship"
+        class="form-control"
+        type="text"
+      >
     </div>
     <div class="form-group">
       <label :for="inputIds.relationship">Assessor’s name</label>
-      <input class="form-control" type="text" :id="inputIds.relationship" v-model="row.name" />
+      <input
+        :id="inputIds.relationship"
+        v-model="row.name"
+        class="form-control"
+        type="text"
+      >
     </div>
     <div class="form-group">
       <label :for="inputIds.position">Assessor’s position</label>
-      <input class="form-control" type="text" :id="inputIds.position" v-model="row.position" />
+      <input
+        :id="inputIds.position"
+        v-model="row.position"
+        class="form-control"
+        type="text"
+      >
     </div>
     <div class="form-group">
       <label :for="inputIds.email">Assessor’s email</label>
-      <input class="form-control" type="email" :id="inputIds.email" v-model="row.email" />
+      <input
+        :id="inputIds.email"
+        v-model="row.email"
+        class="form-control"
+        type="email"
+      >
     </div>
     <div class="form-group">
       <label :for="inputIds.phone">Assessor’s telephone number</label>
-      <input class="form-control" type="tel" :id="inputIds.phone" v-model="row.phone" />
+      <input
+        :id="inputIds.phone"
+        v-model="row.phone"
+        class="form-control"
+        type="tel"
+      >
     </div>
-    <slot name="removeButton"></slot>
+    <slot name="removeButton" />
   </div>
 </template>
 
 <script>
-  import SelectList from '@/components/SelectList';
+import SelectList from '@/components/SelectList';
 
-  export default {
-    components: {
-      SelectList,
-    },
-    props: [
-      'row',
-      'index'
-    ],
-    data() {
-      return {
-        inputIds: {
-          type: `assessor_${this.index}_type`,
-          relationship: `assessor_${this.index}_relationship`,
-          name: `assessor_${this.index}_name`,
-          position: `assessor_${this.index}_position`,
-          email: `assessor_${this.index}_email`,
-          phone: `assessor_${this.index}_phone`,
-        },
-        selectListOptions: {
-          types: [
-            'Professional',
-            'Judicial'
-          ],
-        },
-      };
-    },
-  };
+export default {
+  components: {
+    SelectList,
+  },
+  props: [
+    'row',
+    'index',
+  ],
+  data() {
+    return {
+      inputIds: {
+        type: `assessor_${this.index}_type`,
+        relationship: `assessor_${this.index}_relationship`,
+        name: `assessor_${this.index}_name`,
+        position: `assessor_${this.index}_position`,
+        email: `assessor_${this.index}_email`,
+        phone: `assessor_${this.index}_phone`,
+      },
+      selectListOptions: {
+        types: [
+          'Professional',
+          'Judicial',
+        ],
+      },
+    };
+  },
+};
 </script>

--- a/hosting/apply/src/views/RepeatableFields/Assessor.vue
+++ b/hosting/apply/src/views/RepeatableFields/Assessor.vue
@@ -64,10 +64,16 @@ export default {
   components: {
     SelectList,
   },
-  props: [
-    'row',
-    'index',
-  ],
+  props: {
+    row: {
+      type: Object,
+      required: true,
+    },
+    index: {
+      type: Number,
+      required: true,
+    },
+  },
   data() {
     return {
       inputIds: {

--- a/hosting/apply/src/views/RepeatableFields/ConductDetails.vue
+++ b/hosting/apply/src/views/RepeatableFields/ConductDetails.vue
@@ -41,10 +41,16 @@ export default {
   components: {
     DateInput,
   },
-  props: [
-    'row',
-    'index',
-  ],
+  props: {
+    row: {
+      type: Object,
+      required: true,
+    },
+    index: {
+      type: Number,
+      required: true,
+    },
+  },
   data() {
     return {
       inputIds: {

--- a/hosting/apply/src/views/RepeatableFields/ConductDetails.vue
+++ b/hosting/apply/src/views/RepeatableFields/ConductDetails.vue
@@ -2,44 +2,59 @@
   <div>
     <div class="form-group">
       <label>Date</label>
-      <DateInput v-model="row.date" type="month" />
+      <DateInput
+        v-model="row.date"
+        type="month"
+      />
     </div>
     <div class="form-group">
       <label :for="inputIds.details">Give details</label>
-      <textarea class="form-control" :id="inputIds.details" v-model="row.details" rows="3"></textarea>
+      <textarea
+        :id="inputIds.details"
+        v-model="row.details"
+        class="form-control"
+        rows="3"
+      />
     </div>
     <div class="form-group">
       <label :for="inputIds.circumstances">Circumstances</label>
-      <div class="fieldset-text">Give any circumstances you want to be taken into account when we consider your application</div>
-      <textarea class="form-control" :id="inputIds.circumstances" v-model="row.circumstances" rows="3"></textarea>
+      <div class="fieldset-text">
+        Give any circumstances you want to be taken into account when we consider your application
+      </div>
+      <textarea
+        :id="inputIds.circumstances"
+        v-model="row.circumstances"
+        class="form-control"
+        rows="3"
+      />
     </div>
-    <slot name="removeButton"></slot>
+    <slot name="removeButton" />
   </div>
 </template>
 
 <script>
-  import DateInput from '@/components/DateInput';
-  let uid = 0;
+import DateInput from '@/components/DateInput';
+let uid = 0;
 
-  export default {
-    name: 'ConductDetails',
-    components: {
-      DateInput,
-    },
-    props: [
-      'row',
-      'index'
-    ],
-    data() {
-      return {
-        inputIds: {
-          details: `conduct_${uid}_details`,
-          circumstances: `conduct_${uid}_circumstances`,
-        },
-      };
-    },
-    created() {
-      uid++;
-    },
-  };
+export default {
+  name: 'ConductDetails',
+  components: {
+    DateInput,
+  },
+  props: [
+    'row',
+    'index',
+  ],
+  data() {
+    return {
+      inputIds: {
+        details: `conduct_${uid}_details`,
+        circumstances: `conduct_${uid}_circumstances`,
+      },
+    };
+  },
+  created() {
+    uid++;
+  },
+};
 </script>

--- a/hosting/apply/src/views/RepeatableFields/Experience.vue
+++ b/hosting/apply/src/views/RepeatableFields/Experience.vue
@@ -214,10 +214,16 @@ export default {
     BooleanInput,
     DateInput,
   },
-  props: [
-    'row',
-    'index',
-  ],
+  props: {
+    row: {
+      type: Object,
+      required: true,
+    },
+    index: {
+      type: Number,
+      required: true,
+    },
+  },
   data() {
     return {
       inputIds: {

--- a/hosting/apply/src/views/RepeatableFields/Experience.vue
+++ b/hosting/apply/src/views/RepeatableFields/Experience.vue
@@ -2,7 +2,12 @@
   <div>
     <div class="form-group">
       <label :for="inputIds.title">Title</label>
-      <input type="text" class="form-control" :id="inputIds.title" v-model="row.title">
+      <input
+        :id="inputIds.title"
+        v-model="row.title"
+        type="text"
+        class="form-control"
+      >
     </div>
 
     <div class="form-group">
@@ -10,20 +15,37 @@
       <div class="fieldset-text">
         For example, 02 2017
       </div>
-      <DateInput v-model="row.date_from" type="month" />
+      <DateInput
+        v-model="row.date_from"
+        type="month"
+      />
     </div>
 
     <div class="custom-control custom-checkbox mb-3">
-      <input type="checkbox" class="custom-control-input" :id="inputIds.currentlyInJob" v-model="row.currently_in_job">
-      <label class="custom-control-label" :for="inputIds.currentlyInJob">I currently work in this job</label>
+      <input
+        :id="inputIds.currentlyInJob"
+        v-model="row.currently_in_job"
+        type="checkbox"
+        class="custom-control-input"
+      >
+      <label
+        class="custom-control-label"
+        :for="inputIds.currentlyInJob"
+      >I currently work in this job</label>
     </div>
 
-    <div class="form-group" v-if="!row.currently_in_job">
+    <div
+      v-if="!row.currently_in_job"
+      class="form-group"
+    >
       <label>To</label>
       <div class="fieldset-text">
         For example, 02 2017
       </div>
-      <DateInput v-model="row.date_to" type="month" />
+      <DateInput
+        v-model="row.date_to"
+        type="month"
+      />
     </div>
 
     <div class="form-group">
@@ -36,31 +58,73 @@
       <div class="form-group">
         <label v-if="presentTense">Is the appointment salaried or fee-paid?</label>
         <label v-if="pastTense">Was the appointment salaried or fee-paid?</label>
-        <SelectList :options="selectListOptions.appointmentTypes" v-model="row.appointment_type" :id="inputIds.appointmentType" />
+        <SelectList
+          :id="inputIds.appointmentType"
+          v-model="row.appointment_type"
+          :options="selectListOptions.appointmentTypes"
+        />
       </div>
 
       <div class="form-group">
-        <label v-if="presentTense" :for="inputIds.jurisdiction">What’s your jurisdiction?</label>
-        <label v-if="pastTense" :for="inputIds.jurisdiction">What was your jurisdiction?</label>
-        <input type="text" class="form-control" :id="inputIds.jurisdiction" v-model="row.jurisdiction">
+        <label
+          v-if="presentTense"
+          :for="inputIds.jurisdiction"
+        >What’s your jurisdiction?</label>
+        <label
+          v-if="pastTense"
+          :for="inputIds.jurisdiction"
+        >What was your jurisdiction?</label>
+        <input
+          :id="inputIds.jurisdiction"
+          v-model="row.jurisdiction"
+          type="text"
+          class="form-control"
+        >
       </div>
 
       <div class="form-group">
         <label v-if="presentTense">Which circuit do you work on?</label>
         <label v-if="pastTense">Which circuit did you work on?</label>
-        <SelectList :options="selectListOptions.circuits" v-model="row.circuit" :id="inputIds.circuit" />
+        <SelectList
+          :id="inputIds.circuit"
+          v-model="row.circuit"
+          :options="selectListOptions.circuits"
+        />
       </div>
 
       <div class="form-group">
-        <label v-if="presentTense" :for="inputIds.region">Which region do you work in?</label>
-        <label v-if="pastTense" :for="inputIds.region">Which region did you work in?</label>
-        <input type="text" class="form-control" :id="inputIds.region" v-model="row.region">
+        <label
+          v-if="presentTense"
+          :for="inputIds.region"
+        >Which region do you work in?</label>
+        <label
+          v-if="pastTense"
+          :for="inputIds.region"
+        >Which region did you work in?</label>
+        <input
+          :id="inputIds.region"
+          v-model="row.region"
+          type="text"
+          class="form-control"
+        >
       </div>
 
       <div class="form-group">
-        <label v-if="presentTense" :for="inputIds.daysSat">How many days have you sat in this appointment?</label>
-        <label v-if="pastTense" :for="inputIds.daysSat">How many days did you sit in this appointment?</label>
-        <input type="number" class="form-control" :id="inputIds.daysSat" v-model.number="row.days_sat" style="max-width: 6rem;">
+        <label
+          v-if="presentTense"
+          :for="inputIds.daysSat"
+        >How many days have you sat in this appointment?</label>
+        <label
+          v-if="pastTense"
+          :for="inputIds.daysSat"
+        >How many days did you sit in this appointment?</label>
+        <input
+          :id="inputIds.daysSat"
+          v-model.number="row.days_sat"
+          type="number"
+          class="form-control"
+          style="max-width: 6rem;"
+        >
       </div>
     </div>
 
@@ -73,101 +137,136 @@
 
       <div class="form-group">
         <label :for="inputIds.company">Company or organisation</label>
-        <input type="text" class="form-control" :id="inputIds.company" v-model="row.company">
+        <input
+          :id="inputIds.company"
+          v-model="row.company"
+          type="text"
+          class="form-control"
+        >
       </div>
 
       <div class="form-group">
         <label v-if="presentTense">What law-related activities do you do?</label>
         <label v-if="pastTense">What law-related activities did you do?</label>
-        <div class="fieldset-text">Select all that apply</div>
-        <SelectList :multiple="true" :options="selectListOptions.activities" v-model="row.activities" :id="inputIds.activities" />
+        <div class="fieldset-text">
+          Select all that apply
+        </div>
+        <SelectList
+          :id="inputIds.activities"
+          v-model="row.activities"
+          :multiple="true"
+          :options="selectListOptions.activities"
+        />
         <div class="custom-control custom-checkbox">
-          <input type="checkbox" class="custom-control-input" :id="inputIds.activitiesOther" v-model="row.activities_has_other">
-          <label class="custom-control-label" :for="inputIds.activitiesOther">Other activity that may be considered law-related</label>
-          <input v-if="row.activities_has_other" type="text" class="form-control" v-model="row.activities_other">
+          <input
+            :id="inputIds.activitiesOther"
+            v-model="row.activities_has_other"
+            type="checkbox"
+            class="custom-control-input"
+          >
+          <label
+            class="custom-control-label"
+            :for="inputIds.activitiesOther"
+          >Other activity that may be considered law-related</label>
+          <input
+            v-if="row.activities_has_other"
+            v-model="row.activities_other"
+            type="text"
+            class="form-control"
+          >
         </div>
       </div>
 
       <div class="form-group">
         <label :for="inputIds.mainDuties">Main duties</label>
-        <textarea class="form-control" :id="inputIds.mainDuties" rows="3" v-model="row.main_duties"></textarea>
+        <textarea
+          :id="inputIds.mainDuties"
+          v-model="row.main_duties"
+          class="form-control"
+          rows="3"
+        />
       </div>
 
       <div class="form-group">
         <label :for="inputIds.specialisms">Specialism/s</label>
-        <textarea class="form-control" :id="inputIds.specialisms" rows="3" v-model="row.specialisms"></textarea>
+        <textarea
+          :id="inputIds.specialisms"
+          v-model="row.specialisms"
+          class="form-control"
+          rows="3"
+        />
       </div>
     </div>
 
-    <slot name="removeButton"></slot>
+    <slot name="removeButton" />
   </div>
 </template>
 
 <script>
-  import DateInput from '@/components/DateInput';
-  import BooleanInput from '@/components/BooleanInput';
-  import SelectList from '@/components/SelectList';
+import DateInput from '@/components/DateInput';
+import BooleanInput from '@/components/BooleanInput';
+import SelectList from '@/components/SelectList';
 
-  export default {
-    name: 'Experience',
-    components: {
-      SelectList,
-      BooleanInput,
-      DateInput,
-    },
-    props: [
-      'row',
-      'index'
-    ],
-    data() {
-      return {
-        inputIds: {
-          title: `experience_${this.index}_title`,
-          currentlyInJob: `experience_${this.index}_currently_in_job`,
-          appointmentType: `experience_${this.index}_appointment_type`,
-          jurisdiction: `experience_${this.index}_jurisdiction`,
-          circuit: `experience_${this.index}_circuit`,
-          region: `experience_${this.index}_region`,
-          daysSat: `experience_${this.index}_days_sat`,
-          company: `experience_${this.index}_company`,
-          activities: `experience_${this.index}_activities`,
-          activitiesOther: `experience_${this.index}_activities_other`,
-          mainDuties: `experience_${this.index}_main_duties`,
-          specialisms: `experience_${this.index}_specialisms`,
-        },
-        selectListOptions: {
-          appointmentTypes: [
-            'Salaried',
-            'Fee-paid'
-          ],
-          circuits: [
-            'London and south east',
-            'Western',
-            'Midlands',
-            'Northern',
-            'North eastern',
-            'Wales'
-          ],
-          activities: [
-            'Carrying out of judicial functions of any court or tribunals',
-            'Acting as an arbitrator',
-            'Practising or being employed as a lawyer',
-            'Advising (whether or not in the course of such practice or employment as a lawyer) on the application of the law',
-            'Assisting (whether or not in the course of such practice) persons involved in proceedings for the resolution of issues arising under the law',
-            'Acting (whether or not in the course of such practice) as a mediator in connection with attempts to resolve issues that are the subject of proceedings or could be, if not resolved',
-            'Drafting (whether or not in the course of such practice) documents intended to affect persons’ rights and obligations',
-            'Teaching or researching law'
-          ],
-        },
-      };
-    },
-    computed: {
-      presentTense() {
-        return !!this.row.currently_in_job;
+export default {
+  name: 'Experience',
+  components: {
+    SelectList,
+    BooleanInput,
+    DateInput,
+  },
+  props: [
+    'row',
+    'index',
+  ],
+  data() {
+    return {
+      inputIds: {
+        title: `experience_${this.index}_title`,
+        currentlyInJob: `experience_${this.index}_currently_in_job`,
+        appointmentType: `experience_${this.index}_appointment_type`,
+        jurisdiction: `experience_${this.index}_jurisdiction`,
+        circuit: `experience_${this.index}_circuit`,
+        region: `experience_${this.index}_region`,
+        daysSat: `experience_${this.index}_days_sat`,
+        company: `experience_${this.index}_company`,
+        activities: `experience_${this.index}_activities`,
+        activitiesOther: `experience_${this.index}_activities_other`,
+        mainDuties: `experience_${this.index}_main_duties`,
+        specialisms: `experience_${this.index}_specialisms`,
       },
-      pastTense() {
-        return !this.row.currently_in_job;
+      selectListOptions: {
+        appointmentTypes: [
+          'Salaried',
+          'Fee-paid',
+        ],
+        circuits: [
+          'London and south east',
+          'Western',
+          'Midlands',
+          'Northern',
+          'North eastern',
+          'Wales',
+        ],
+        activities: [
+          'Carrying out of judicial functions of any court or tribunals',
+          'Acting as an arbitrator',
+          'Practising or being employed as a lawyer',
+          'Advising (whether or not in the course of such practice or employment as a lawyer) on the application of the law',
+          'Assisting (whether or not in the course of such practice) persons involved in proceedings for the resolution of issues arising under the law',
+          'Acting (whether or not in the course of such practice) as a mediator in connection with attempts to resolve issues that are the subject of proceedings or could be, if not resolved',
+          'Drafting (whether or not in the course of such practice) documents intended to affect persons’ rights and obligations',
+          'Teaching or researching law',
+        ],
       },
+    };
+  },
+  computed: {
+    presentTense() {
+      return !!this.row.currently_in_job;
     },
-  };
+    pastTense() {
+      return !this.row.currently_in_job;
+    },
+  },
+};
 </script>

--- a/hosting/apply/src/views/RepeatableFields/OffenceDetails.vue
+++ b/hosting/apply/src/views/RepeatableFields/OffenceDetails.vue
@@ -57,10 +57,16 @@ export default {
   components: {
     DateInput,
   },
-  props: [
-    'row',
-    'index',
-  ],
+  props: {
+    row: {
+      type: Object,
+      required: true,
+    },
+    index: {
+      type: Number,
+      required: true,
+    },
+  },
   data() {
     return {
       inputIds: {

--- a/hosting/apply/src/views/RepeatableFields/OffenceDetails.vue
+++ b/hosting/apply/src/views/RepeatableFields/OffenceDetails.vue
@@ -2,53 +2,76 @@
   <div>
     <div class="form-group">
       <label :for="inputIds.offence">Offence</label>
-      <input type="text" class="form-control" :id="inputIds.offence" v-model="row.offence">
+      <input
+        :id="inputIds.offence"
+        v-model="row.offence"
+        type="text"
+        class="form-control"
+      >
     </div>
     <div class="form-group">
       <label>Date of offence</label>
-      <DateInput v-model="row.offence_date" type="month" />
+      <DateInput
+        v-model="row.offence_date"
+        type="month"
+      />
     </div>
     <div class="form-group">
       <label :for="inputIds.sentence">Sentence or penalty</label>
-      <input type="text" class="form-control" :id="inputIds.sentence" v-model="row.sentence">
+      <input
+        :id="inputIds.sentence"
+        v-model="row.sentence"
+        type="text"
+        class="form-control"
+      >
     </div>
     <div class="form-group">
       <label>Date of sentence or penalty</label>
-      <DateInput v-model="row.sentence_date" type="month" />
+      <DateInput
+        v-model="row.sentence_date"
+        type="month"
+      />
     </div>
     <div class="form-group">
       <label :for="inputIds.circumstances">Circumstances</label>
-      <div class="fieldset-text">Give any circumstances you want to be taken into account when we consider your application</div>
-      <textarea class="form-control" :id="inputIds.circumstances" v-model="row.circumstances" rows="3"></textarea>
+      <div class="fieldset-text">
+        Give any circumstances you want to be taken into account when we consider your application
+      </div>
+      <textarea
+        :id="inputIds.circumstances"
+        v-model="row.circumstances"
+        class="form-control"
+        rows="3"
+      />
     </div>
-    <slot name="removeButton"></slot>
+    <slot name="removeButton" />
   </div>
 </template>
 
 <script>
-  import DateInput from '@/components/DateInput';
-  let uid = 0;
+import DateInput from '@/components/DateInput';
+let uid = 0;
 
-  export default {
-    name: 'OffenceDetails',
-    components: {
-      DateInput,
-    },
-    props: [
-      'row',
-      'index'
-    ],
-    data() {
-      return {
-        inputIds: {
-          offence: `offence_${uid}_offence`,
-          sentence: `offence_${uid}_sentence`,
-          circumstances: `offence_${uid}_circumstances`,
-        },
-      };
-    },
-    created() {
-      uid++;
-    },
-  };
+export default {
+  name: 'OffenceDetails',
+  components: {
+    DateInput,
+  },
+  props: [
+    'row',
+    'index',
+  ],
+  data() {
+    return {
+      inputIds: {
+        offence: `offence_${uid}_offence`,
+        sentence: `offence_${uid}_sentence`,
+        circumstances: `offence_${uid}_circumstances`,
+      },
+    };
+  },
+  created() {
+    uid++;
+  },
+};
 </script>

--- a/hosting/apply/src/views/RepeatableFields/Qualification.vue
+++ b/hosting/apply/src/views/RepeatableFields/Qualification.vue
@@ -2,42 +2,55 @@
   <div>
     <div class="form-group">
       <label :for="qualificationInputId">Qualification</label>
-      <input type="text" class="form-control" :id="qualificationInputId" v-model="row.qualification">
+      <input
+        :id="qualificationInputId"
+        v-model="row.qualification"
+        type="text"
+        class="form-control"
+      >
     </div>
     <div class="form-group">
       <label :for="collegeInputId">College or university</label>
-      <input type="text" class="form-control" :id="collegeInputId" v-model="row.college">
+      <input
+        :id="collegeInputId"
+        v-model="row.college"
+        type="text"
+        class="form-control"
+      >
     </div>
     <div class="form-group">
       <label>Qualification date</label>
       <div class="fieldset-text">
         For example, 02 2017
       </div>
-      <DateInput v-model="row.date" type="month" />
+      <DateInput
+        v-model="row.date"
+        type="month"
+      />
     </div>
-    <slot name="removeButton"></slot>
+    <slot name="removeButton" />
   </div>
 </template>
 
 <script>
-  import DateInput from '@/components/DateInput';
+import DateInput from '@/components/DateInput';
 
-  export default {
-    name: 'Qualification',
-    components: {
-      DateInput,
+export default {
+  name: 'Qualification',
+  components: {
+    DateInput,
+  },
+  props: [
+    'row',
+    'index',
+  ],
+  computed: {
+    qualificationInputId() {
+      return `qualification_${this.index}_qualification`;
     },
-    props: [
-      'row',
-      'index'
-    ],
-    computed: {
-      qualificationInputId() {
-        return `qualification_${this.index}_qualification`;
-      },
-      collegeInputId() {
-        return `qualification_${this.index}_college`;
-      },
+    collegeInputId() {
+      return `qualification_${this.index}_college`;
     },
-  };
+  },
+};
 </script>

--- a/hosting/apply/src/views/RepeatableFields/Qualification.vue
+++ b/hosting/apply/src/views/RepeatableFields/Qualification.vue
@@ -40,10 +40,16 @@ export default {
   components: {
     DateInput,
   },
-  props: [
-    'row',
-    'index',
-  ],
+  props: {
+    row: {
+      type: Object,
+      required: true,
+    },
+    index: {
+      type: Number,
+      required: true,
+    },
+  },
   computed: {
     qualificationInputId() {
       return `qualification_${this.index}_qualification`;

--- a/hosting/apply/src/views/Sections/Assessors/Edit.vue
+++ b/hosting/apply/src/views/Sections/Assessors/Edit.vue
@@ -6,48 +6,58 @@
       <fieldset>
         <legend>Your assessors</legend>
         <div class="fieldset-text">
-          <a href="https://www.judicialappointments.gov.uk/references-guidance-candidates" target="_blank">
+          <a
+            href="https://www.judicialappointments.gov.uk/references-guidance-candidates"
+            target="_blank"
+          >
             Guidance on choosing your two assessors
           </a>
         </div>
-        <RepeatableFields v-model="applicant.assessors" :component="repeatableFields.Assessor" :max="2" />
+        <RepeatableFields
+          v-model="applicant.assessors"
+          :component="repeatableFields.Assessor"
+          :max="2"
+        />
       </fieldset>
 
-      <SaveAndContinueButtons :isSaving="isSaving" @saveAndContinue="saveAndContinue" />
+      <SaveAndContinueButtons
+        :is-saving="isSaving"
+        @saveAndContinue="saveAndContinue"
+      />
     </form>
   </section>
 </template>
 
 <script>
-  import Assessor from '@/views/RepeatableFields/Assessor';
-  import RepeatableFields from '@/components/RepeatableFields';
-  import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
+import Assessor from '@/views/RepeatableFields/Assessor';
+import RepeatableFields from '@/components/RepeatableFields';
+import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
 
-  export default {
-    components: {
-      SaveAndContinueButtons,
-      RepeatableFields,
-    },
-    data() {
-      return {
-        applicant: this.$store.getters.applicant(),
-        vacancy: this.$store.getters.vacancy,
-        isSaving: false,
-        repeatableFields: {
-          Assessor,
-        },
-      };
-    },
-    methods: {
-      async saveAndContinue() {
-        await this.save();
-        this.$emit('continue');
+export default {
+  components: {
+    SaveAndContinueButtons,
+    RepeatableFields,
+  },
+  data() {
+    return {
+      applicant: this.$store.getters.applicant(),
+      vacancy: this.$store.getters.vacancy,
+      isSaving: false,
+      repeatableFields: {
+        Assessor,
       },
-      async save() {
-        this.isSaving = true;
-        await this.$store.dispatch('saveApplicant', this.applicant);
-        this.isSaving = false;
-      },
+    };
+  },
+  methods: {
+    async saveAndContinue() {
+      await this.save();
+      this.$emit('continue');
     },
-  };
+    async save() {
+      this.isSaving = true;
+      await this.$store.dispatch('saveApplicant', this.applicant);
+      this.isSaving = false;
+    },
+  },
+};
 </script>

--- a/hosting/apply/src/views/Sections/Assessors/Show.vue
+++ b/hosting/apply/src/views/Sections/Assessors/Show.vue
@@ -1,11 +1,17 @@
 <template>
   <section class="card mb-3">
     <div class="card-header">
-      <h3 class="card-title">Your assessors</h3>
+      <h3 class="card-title">
+        Your assessors
+      </h3>
     </div>
 
     <div class="card-body">
-      <table class="table mb-6" v-for="assessor in applicant.assessors" :key="assessor.id">
+      <table
+        v-for="assessor in applicant.assessors"
+        :key="assessor.id"
+        class="table mb-6"
+      >
         <tbody>
           <tr>
             <th>Assessor Type</th>
@@ -33,7 +39,12 @@
           </tr>
           <tr>
             <td colspan="10">
-              <RouterLink to="/apply/assessors" class="float-right">Change</RouterLink>
+              <RouterLink
+                to="/apply/assessors"
+                class="float-right"
+              >
+                Change
+              </RouterLink>
             </td>
           </tr>
         </tbody>
@@ -43,11 +54,11 @@
 </template>
 
 <script>
-  export default {
-    data() {
-      return {
-        applicant: this.$store.getters.applicant(),
-      };
-    },
-  };
+export default {
+  data() {
+    return {
+      applicant: this.$store.getters.applicant(),
+    };
+  },
+};
 </script>

--- a/hosting/apply/src/views/Sections/Character/Edit.vue
+++ b/hosting/apply/src/views/Sections/Character/Edit.vue
@@ -8,26 +8,51 @@
 
         <label>Have you ever been convicted of, cautioned for or received a conditional caution for a motoring offence (other than a parking offence)?</label>
         <BooleanInput v-model="applicant.character_has_motoring_offences" />
-        <RepeatableFields v-if="applicant.character_has_motoring_offences" v-model="applicant.character_motoring_offences" :component="repeatableFields.OffenceDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_motoring_offences"
+          v-model="applicant.character_motoring_offences"
+          :component="repeatableFields.OffenceDetails"
+          class="mt-3"
+        />
 
         <label class="mt-3">Have you ever received a penalty notice?</label>
         <BooleanInput v-model="applicant.character_has_penalty_notices" />
-        <RepeatableFields v-if="applicant.character_has_penalty_notices" v-model="applicant.character_penalty_notices" :component="repeatableFields.OffenceDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_penalty_notices"
+          v-model="applicant.character_penalty_notices"
+          :component="repeatableFields.OffenceDetails"
+          class="mt-3"
+        />
 
         <label class="mt-3">Have you received any fixed penalty notices in the past 4 years?</label>
         <BooleanInput v-model="applicant.character_has_fixed_penalty_notices" />
-        <RepeatableFields v-if="applicant.character_has_fixed_penalty_notices" v-model="applicant.character_fixed_penalty_notices" :component="repeatableFields.OffenceDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_fixed_penalty_notices"
+          v-model="applicant.character_fixed_penalty_notices"
+          :component="repeatableFields.OffenceDetails"
+          class="mt-3"
+        />
 
         <label class="mt-3">Have you received any endorsements ordered on your licence in the past 4 years?</label>
         <BooleanInput v-model="applicant.character_has_licence_endorsements" />
-        <RepeatableFields v-if="applicant.character_has_licence_endorsements" v-model="applicant.character_licence_endorsements" :component="repeatableFields.OffenceDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_licence_endorsements"
+          v-model="applicant.character_licence_endorsements"
+          :component="repeatableFields.OffenceDetails"
+          class="mt-3"
+        />
       </fieldset>
 
       <fieldset>
         <legend>Criminal offences</legend>
         <label>Have you ever been convicted of or cautioned for a criminal offence?</label>
         <BooleanInput v-model="applicant.character_has_criminal_offences" />
-        <RepeatableFields v-if="applicant.character_has_criminal_offences" v-model="applicant.character_criminal_offences" :component="repeatableFields.OffenceDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_criminal_offences"
+          v-model="applicant.character_criminal_offences"
+          :component="repeatableFields.OffenceDetails"
+          class="mt-3"
+        />
       </fieldset>
 
       <fieldset>
@@ -35,19 +60,39 @@
 
         <label>Have you ever been declared bankrupt?</label>
         <BooleanInput v-model="applicant.character_has_bankruptcies" />
-        <RepeatableFields v-if="applicant.character_has_bankruptcies" v-model="applicant.character_bankruptcies" :component="repeatableFields.ConductDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_bankruptcies"
+          v-model="applicant.character_bankruptcies"
+          :component="repeatableFields.ConductDetails"
+          class="mt-3"
+        />
 
         <label class="mt-3">Have you ever enter into an Individual Voluntary Arrangement (IVA)?</label>
         <BooleanInput v-model="applicant.character_has_ivas" />
-        <RepeatableFields v-if="applicant.character_has_ivas" v-model="applicant.character_ivas" :component="repeatableFields.ConductDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_ivas"
+          v-model="applicant.character_ivas"
+          :component="repeatableFields.ConductDetails"
+          class="mt-3"
+        />
 
         <label class="mt-3">Have you ever been sued in relation to any debt?</label>
         <BooleanInput v-model="applicant.character_has_sued_for_debts" />
-        <RepeatableFields v-if="applicant.character_has_sued_for_debts" v-model="applicant.character_sued_for_debts" :component="repeatableFields.ConductDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_sued_for_debts"
+          v-model="applicant.character_sued_for_debts"
+          :component="repeatableFields.ConductDetails"
+          class="mt-3"
+        />
 
         <label class="mt-3">Have you ever been a director of a company that has become insolvent?</label>
         <BooleanInput v-model="applicant.character_has_director_insolvencies" />
-        <RepeatableFields v-if="applicant.character_has_director_insolvencies" v-model="applicant.character_director_insolvencies" :component="repeatableFields.ConductDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_director_insolvencies"
+          v-model="applicant.character_director_insolvencies"
+          :component="repeatableFields.ConductDetails"
+          class="mt-3"
+        />
       </fieldset>
 
       <fieldset>
@@ -55,11 +100,21 @@
 
         <label>Have you or your company ever received a penalty for any VAT or tax assessments?</label>
         <BooleanInput v-model="applicant.character_has_tax_penalties" />
-        <RepeatableFields v-if="applicant.character_has_tax_penalties" v-model="applicant.character_tax_penalties" :component="repeatableFields.ConductDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_tax_penalties"
+          v-model="applicant.character_tax_penalties"
+          :component="repeatableFields.ConductDetails"
+          class="mt-3"
+        />
 
         <label class="mt-3">Have you or your company ever been penalised for submitting a late VAT or tax return, including through a county court?</label>
         <BooleanInput v-model="applicant.character_has_late_tax_returns" />
-        <RepeatableFields v-if="applicant.character_has_late_tax_returns" v-model="applicant.character_late_tax_returns" :component="repeatableFields.ConductDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_late_tax_returns"
+          v-model="applicant.character_late_tax_returns"
+          :component="repeatableFields.ConductDetails"
+          class="mt-3"
+        />
       </fieldset>
 
       <fieldset>
@@ -67,82 +122,127 @@
 
         <label>Have you or your company ever had a finding of professional negligence against you?</label>
         <BooleanInput v-model="applicant.character_has_professional_negligence" />
-        <RepeatableFields v-if="applicant.character_has_professional_negligence" v-model="applicant.character_professional_negligence" :component="repeatableFields.ConductDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_professional_negligence"
+          v-model="applicant.character_professional_negligence"
+          :component="repeatableFields.ConductDetails"
+          class="mt-3"
+        />
 
         <label class="mt-3">Have you or your company ever been involved in unfair or wrongful dismissal or discrimination or any other adverse civil proceedings against you?</label>
         <BooleanInput v-model="applicant.character_has_wrongful_dismissals" />
-        <RepeatableFields v-if="applicant.character_has_wrongful_dismissals" v-model="applicant.character_wrongful_dismissals" :component="repeatableFields.ConductDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_wrongful_dismissals"
+          v-model="applicant.character_wrongful_dismissals"
+          :component="repeatableFields.ConductDetails"
+          class="mt-3"
+        />
 
         <label class="mt-3">Have you or your company ever had a finding of professional misconduct against you?</label>
         <BooleanInput v-model="applicant.character_has_professional_misconduct" />
-        <RepeatableFields v-if="applicant.character_has_professional_misconduct" v-model="applicant.character_professional_misconduct" :component="repeatableFields.ConductDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_professional_misconduct"
+          v-model="applicant.character_professional_misconduct"
+          :component="repeatableFields.ConductDetails"
+          class="mt-3"
+        />
 
         <label class="mt-3">Have you or your company ever had a finding of inadequate professional service against you?</label>
         <BooleanInput v-model="applicant.character_has_inadequate_professional_service" />
-        <RepeatableFields v-if="applicant.character_has_inadequate_professional_service" v-model="applicant.character_inadequate_professional_service" :component="repeatableFields.ConductDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_inadequate_professional_service"
+          v-model="applicant.character_inadequate_professional_service"
+          :component="repeatableFields.ConductDetails"
+          class="mt-3"
+        />
 
         <label class="mt-3">Have you ever had any other type of complaint raised against you?</label>
         <BooleanInput v-model="applicant.character_has_other_complaints" />
-        <RepeatableFields v-if="applicant.character_has_other_complaints" v-model="applicant.character_other_complaints" :component="repeatableFields.ConductDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_other_complaints"
+          v-model="applicant.character_other_complaints"
+          :component="repeatableFields.ConductDetails"
+          class="mt-3"
+        />
 
         <label class="mt-3">Have you ever been asked to resign, or been dismissed from, employment or judicial office?</label>
         <BooleanInput v-model="applicant.character_has_dismissals" />
-        <RepeatableFields v-if="applicant.character_has_dismissals" v-model="applicant.character_dismissals" :component="repeatableFields.ConductDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_dismissals"
+          v-model="applicant.character_dismissals"
+          :component="repeatableFields.ConductDetails"
+          class="mt-3"
+        />
       </fieldset>
 
       <fieldset>
         <legend>Current investigations or proceedings</legend>
         <label>Are you involved in any current investigations?</label>
         <BooleanInput v-model="applicant.character_has_current_investigations" />
-        <RepeatableFields v-if="applicant.character_has_current_investigations" v-model="applicant.character_current_investigations" :component="repeatableFields.ConductDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_current_investigations"
+          v-model="applicant.character_current_investigations"
+          :component="repeatableFields.ConductDetails"
+          class="mt-3"
+        />
       </fieldset>
 
       <fieldset>
         <legend>Additional information</legend>
         <label class="mt-3">Is there anything else that is relevant to your character that you haven't already told us?</label>
-        <div class="fieldset-text">For example, anything which might make a member of the public think you're unsuitable for this post</div>
+        <div class="fieldset-text">
+          For example, anything which might make a member of the public think you're unsuitable for this post
+        </div>
         <BooleanInput v-model="applicant.character_has_other" />
-        <RepeatableFields v-if="applicant.character_has_other" v-model="applicant.character_other" :component="repeatableFields.ConductDetails" class="mt-3" />
+        <RepeatableFields
+          v-if="applicant.character_has_other"
+          v-model="applicant.character_other"
+          :component="repeatableFields.ConductDetails"
+          class="mt-3"
+        />
       </fieldset>
 
-      <SaveAndContinueButtons :isSaving="isSaving" @saveAndContinue="saveAndContinue" />
+      <SaveAndContinueButtons
+        :is-saving="isSaving"
+        @saveAndContinue="saveAndContinue"
+      />
     </form>
   </section>
 </template>
 
 <script>
-  import BooleanInput from '@/components/BooleanInput';
-  import RepeatableFields from '@/components/RepeatableFields';
-  import OffenceDetails from '@/views/RepeatableFields/OffenceDetails';
-  import ConductDetails from '@/views/RepeatableFields/ConductDetails';
-  import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
+import BooleanInput from '@/components/BooleanInput';
+import RepeatableFields from '@/components/RepeatableFields';
+import OffenceDetails from '@/views/RepeatableFields/OffenceDetails';
+import ConductDetails from '@/views/RepeatableFields/ConductDetails';
+import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
 
-  export default {
-    components: {
-      SaveAndContinueButtons,
-      RepeatableFields,
-      BooleanInput,
-    },
-    data() {
-      return {
-        applicant: this.$store.getters.applicant(),
-        isSaving: false,
-        repeatableFields: {
-          OffenceDetails,
-          ConductDetails,
-        },
-      };
-    },
-    methods: {
-      async saveAndContinue() {
-        await this.save();
-        this.$emit('continue');
+export default {
+  components: {
+    SaveAndContinueButtons,
+    RepeatableFields,
+    BooleanInput,
+  },
+  data() {
+    return {
+      applicant: this.$store.getters.applicant(),
+      isSaving: false,
+      repeatableFields: {
+        OffenceDetails,
+        ConductDetails,
       },
-      async save() {
-        this.isSaving = true;
-        await this.$store.dispatch('saveApplicant', this.applicant);
-        this.isSaving = false;
-      },
+    };
+  },
+  methods: {
+    async saveAndContinue() {
+      await this.save();
+      this.$emit('continue');
     },
-  };
+    async save() {
+      this.isSaving = true;
+      await this.$store.dispatch('saveApplicant', this.applicant);
+      this.isSaving = false;
+    },
+  },
+};
 </script>

--- a/hosting/apply/src/views/Sections/Character/Show.vue
+++ b/hosting/apply/src/views/Sections/Character/Show.vue
@@ -1,7 +1,9 @@
 <template>
   <section class="card mb-3">
     <div class="card-header">
-      <h3 class="card-title">Your Character</h3>
+      <h3 class="card-title">
+        Your Character
+      </h3>
     </div>
     <div class="card-body">
       <h4>Motoring Offences</h4>
@@ -10,137 +12,137 @@
         conditional caution for a motoring offence (other than a parking
         offence)?"
         :records="applicant.character_motoring_offences"
-        :answeredYes="applicant.character_has_motoring_offences"
-        />
+        :answered-yes="applicant.character_has_motoring_offences"
+      />
       <CharacterTable
         title="Have you ever received a penalty notice?"
-        :answeredYes="applicant.character_has_penalty_notices"
+        :answered-yes="applicant.character_has_penalty_notices"
         :records="applicant.character_penalty_notices"
-        />
+      />
       <CharacterTable
         title="Have you received any fixed penalty notices in the past 4 years?"
-        :answeredYes="applicant.character_has_fixed_penalty_notices"
+        :answered-yes="applicant.character_has_fixed_penalty_notices"
         :records="applicant.character_fixed_penalty_notices"
-        />
+      />
       <CharacterTable
         title="Have you received any endorsements ordered on your licence in the past 4 years?"
-        :answeredYes="applicant.character_has_licence_endorsements"
+        :answered-yes="applicant.character_has_licence_endorsements"
         :records="applicant.character_licence_endorsements"
-        />
+      />
 
       <h4>Criminal Offences</h4>
       <CharacterTable
         title="Have you ever been convicted of or cautioned for a criminal offence?"
-        :answeredYes="applicant.character_has_criminal_offences"
+        :answered-yes="applicant.character_has_criminal_offences"
         :records="applicant.character_criminal_offences"
-        />
+      />
 
       <h4>
         Insolvency and debt
       </h4>
       <CharacterTable
         title="Have you ever been declared bankrupt?"
-        :answeredYes="applicant.character_has_bankruptcies"
+        :answered-yes="applicant.character_has_bankruptcies"
         :records="applicant.character_bankruptcies"
-        />
+      />
       <CharacterTable
         title="Have you ever enter into an Individual Voluntary Arrangement (IVA)?"
-        :answeredYes="applicant.character_has_ivas"
+        :answered-yes="applicant.character_has_ivas"
         :records="applicant.character_ivas"
-        />
+      />
       <CharacterTable
         title="Have you ever been sued in relation to any debt?"
-        :answeredYes="applicant.character_has_sued_for_debts"
+        :answered-yes="applicant.character_has_sued_for_debts"
         :records="applicant.character_sued_for_debts"
-        />
+      />
       <CharacterTable
         title="Have you ever been a director of a company that has become insolvent?"
-        :answeredYes="applicant.character_has_director_insolvencies"
+        :answered-yes="applicant.character_has_director_insolvencies"
         :records="applicant.character_director_insolvencies"
-        />
+      />
 
       <h4>VAT and tax</h4>
       <CharacterTable
         title="Have you or your company ever received a penalty for any VAT or tax assessments?"
-        :answeredYes="applicant.character_has_tax_penalties"
+        :answered-yes="applicant.character_has_tax_penalties"
         :records="applicant.character_tax_penalties"
-        />
+      />
       <CharacterTable
         title="Have you or your company ever been penalised for submitting a late VAT or tax return, including through a county court?"
-        :answeredYes="applicant.character_has_late_tax_returns"
+        :answered-yes="applicant.character_has_late_tax_returns"
         :records="applicant.character_late_tax_returns"
-        />
+      />
       <CharacterTable
         title="Have you or your company ever been penalised for submitting a late VAT or tax return, including through a county court?"
-        :answeredYes="applicant.character_has_late_tax_returns"
+        :answered-yes="applicant.character_has_late_tax_returns"
         :records="applicant.character_late_tax_returns"
-        />
+      />
 
       <h4>Professional conduct</h4>
       <CharacterTable
         title="Have you or your company ever had a finding of professional negligence against you?"
-        :answeredYes="applicant.character_has_professional_negligence"
+        :answered-yes="applicant.character_has_professional_negligence"
         :records="applicant.character_professional_negligence"
-        />
+      />
       <CharacterTable
         title="Have you or your company ever been involved in unfair or wrongful dismissal or discrimination or any other adverse civil proceedings against you?"
-        :answeredYes="applicant.character_has_wrongful_dismissals"
+        :answered-yes="applicant.character_has_wrongful_dismissals"
         :records="applicant.character_wrongful_dismissals"
-        />
+      />
       <CharacterTable
         title="Have you or your company ever had a finding of professional misconduct against you?"
-        :answeredYes="applicant.character_has_professional_misconduct"
+        :answered-yes="applicant.character_has_professional_misconduct"
         :records="applicant.character_professional_misconduct"
-        />
+      />
       <CharacterTable
         title="Have you or your company ever had a finding of professional misconduct against you?"
-        :answeredYes="applicant.character_has_professional_misconduct"
+        :answered-yes="applicant.character_has_professional_misconduct"
         :records="applicant.character_professional_misconduct"
-        />
+      />
       <CharacterTable
         title="Have you or your company ever had a finding of inadequate professional service against you?"
-        :answeredYes="applicant.character_has_inadequate_professional_service"
+        :answered-yes="applicant.character_has_inadequate_professional_service"
         :records="applicant.character_inadequate_professional_service"
-        />
+      />
       <CharacterTable
         title="Have you ever had any other type of complaint raised against you?"
-        :answeredYes="applicant.character_has_other_complaints"
+        :answered-yes="applicant.character_has_other_complaints"
         :records="applicant.character_other_complaints"
-        />
+      />
       <CharacterTable
         title="Have you ever been asked to resign, or been dismissed from, employment or judicial office?"
-        :answeredYes="applicant.character_has_dismissals"
+        :answered-yes="applicant.character_has_dismissals"
         :records="applicant.character_dissmissals"
-        />
+      />
 
       <h4>Current investigations or proceedings</h4>
       <CharacterTable
         title="Are you involved in any current investigations?"
-        :answeredYes="applicant.character_has_current_investigations"
+        :answered-yes="applicant.character_has_current_investigations"
         :records="applicant.character_current_investigations"
-        />
+      />
 
       <h4>Additional information</h4>
       <CharacterTable
         title="Is there anything else that is relevant to your character that you haven't already told us?"
-        :answeredYes="applicant.character_has_other"
+        :answered-yes="applicant.character_has_other"
         :records="applicant.character_other"
-        />
+      />
     </div>
   </section>
 </template>
 
 <script>
-  import CharacterTable from '@/components/Review/CharacterTable';
+import CharacterTable from '@/components/Review/CharacterTable';
 
-  export default {
-    components: {
-      CharacterTable,
-    },
-    data() {
-      return {
-        applicant: this.$store.getters.applicant(),
-      };
-    },
-  };
+export default {
+  components: {
+    CharacterTable,
+  },
+  data() {
+    return {
+      applicant: this.$store.getters.applicant(),
+    };
+  },
+};
 </script>

--- a/hosting/apply/src/views/Sections/Citizenship/Edit.vue
+++ b/hosting/apply/src/views/Sections/Citizenship/Edit.vue
@@ -5,48 +5,58 @@
 
       <fieldset>
         <legend>What is your citizenship?</legend>
-        <SelectList id="nationality" :options="options" v-model="applicant.citizenship" />
-        <div v-if="applicant.citizenship === 'Non-Commonwealth'" class="mt-3">
+        <SelectList
+          id="nationality"
+          v-model="applicant.citizenship"
+          :options="options"
+        />
+        <div
+          v-if="applicant.citizenship === 'Non-Commonwealth'"
+          class="mt-3"
+        >
           Email <a href="mailto:dcj128@judicialappointments.gov.uk">dcj128@judicialappointments.gov.uk</a> to provide further details
         </div>
       </fieldset>
 
-      <SaveAndContinueButtons :isSaving="isSaving" @saveAndContinue="saveAndContinue" />
+      <SaveAndContinueButtons
+        :is-saving="isSaving"
+        @saveAndContinue="saveAndContinue"
+      />
     </form>
   </section>
 </template>
 
 <script>
-  import SelectList from '@/components/SelectList';
-  import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
+import SelectList from '@/components/SelectList';
+import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
 
-  export default {
-    components: {
-      SaveAndContinueButtons,
-      SelectList,
+export default {
+  components: {
+    SaveAndContinueButtons,
+    SelectList,
+  },
+  data() {
+    return {
+      applicant: this.$store.getters.applicant(),
+      isSaving: false,
+      options: [
+        {value: 'British', label: 'I am a citizen of the United Kingdom'},
+        {value: 'Irish', label: 'I am a citizen of the Republic of Ireland'},
+        {value: 'Commonwealth', label: 'I am a citizen of another Commonwealth country'},
+        {value: 'Non-Commonwealth', label: 'I am none of these'},
+      ],
+    };
+  },
+  methods: {
+    async save() {
+      this.isSaving = true;
+      await this.$store.dispatch('saveApplicant', this.applicant);
+      this.isSaving = false;
     },
-    data() {
-      return {
-        applicant: this.$store.getters.applicant(),
-        isSaving: false,
-        options: [
-          {value: 'British', label: 'I am a citizen of the United Kingdom',},
-          {value: 'Irish', label: 'I am a citizen of the Republic of Ireland',},
-          {value: 'Commonwealth', label: 'I am a citizen of another Commonwealth country',},
-          {value: 'Non-Commonwealth', label: 'I am none of these',}
-        ],
-      };
+    async saveAndContinue() {
+      await this.save();
+      this.$emit('continue');
     },
-    methods: {
-      async save() {
-        this.isSaving = true;
-        await this.$store.dispatch('saveApplicant', this.applicant);
-        this.isSaving = false;
-      },
-      async saveAndContinue() {
-        await this.save();
-        this.$emit('continue');
-      },
-    },
-  };
+  },
+};
 </script>

--- a/hosting/apply/src/views/Sections/Citizenship/Show.vue
+++ b/hosting/apply/src/views/Sections/Citizenship/Show.vue
@@ -1,23 +1,32 @@
 <template>
   <section class="card mb-3">
     <div class="card-header">
-      <h3 class="card-title">Citizenship</h3>
+      <h3 class="card-title">
+        Citizenship
+      </h3>
     </div>
 
     <div class="card-body">
       <table class="table">
         <tbody>
           <tr>
-            <th scope="row">What is your citizenship?</th>
+            <th scope="row">
+              What is your citizenship?
+            </th>
             <td>{{ options[applicant.citizenship] }}</td>
             <td>
-              <RouterLink to="/apply/citizenship">Change</RouterLink>
+              <RouterLink to="/apply/citizenship">
+                Change
+              </RouterLink>
             </td>
           </tr>
         </tbody>
       </table>
 
-      <div v-if="applicant.citizenship === 'Non-Commonwealth'" class="mt-3">
+      <div
+        v-if="applicant.citizenship === 'Non-Commonwealth'"
+        class="mt-3"
+      >
         Email <a href="mailto:dcj128@judicialappointments.gov.uk">dcj128@judicialappointments.gov.uk</a> to provide further details
       </div>
     </div>

--- a/hosting/apply/src/views/Sections/Declarations/Edit.vue
+++ b/hosting/apply/src/views/Sections/Declarations/Edit.vue
@@ -7,16 +7,35 @@
         <legend>Are you related to, or known to any of the JAC Commissioners?</legend>
         <BooleanInput v-model="applicant.are_you_known_to_the_commissioners" />
 
-        <div class="form-group mt-3" v-if="applicant.are_you_known_to_the_commissioners">
+        <div
+          v-if="applicant.are_you_known_to_the_commissioners"
+          class="form-group mt-3"
+        >
           <label for="known_to_commissioners">Select all the Commissioners that apply:</label>
-          <SelectList id="known_to_commissioners" :multiple="true" :options="selectListOptions.known_to_commissioners" v-model="applicant.known_to_commissioners" />
+          <SelectList
+            id="known_to_commissioners"
+            v-model="applicant.known_to_commissioners"
+            :multiple="true"
+            :options="selectListOptions.known_to_commissioners"
+          />
         </div>
-        <div class="form-group mt-3" v-if="applicant.are_you_known_to_the_commissioners">
+        <div
+          v-if="applicant.are_you_known_to_the_commissioners"
+          class="form-group mt-3"
+        >
           <label for="how_do_you_know_them_details">How do you know them?</label>
-          <textarea id="how_do_you_know_them_details" class="form-control" v-model="applicant.how_do_you_know_the_commissioners" placeholder="Please provide details."></textarea>
+          <textarea
+            id="how_do_you_know_them_details"
+            v-model="applicant.how_do_you_know_the_commissioners"
+            class="form-control"
+            placeholder="Please provide details."
+          />
         </div>
       </fieldset>
-      <SaveAndContinueButtons :isSaving="isSaving" @saveAndContinue="saveAndContinue" />
+      <SaveAndContinueButtons
+        :is-saving="isSaving"
+        @saveAndContinue="saveAndContinue"
+      />
     </form>
   </section>
 </template>
@@ -51,7 +70,7 @@ export default {
           'Dame Valerie Strachan DCB',
           'His Honour Judge Phillip Sycamore',
           'Sir Simon Wessely',
-          'Dame Philippa Whipple DBE'
+          'Dame Philippa Whipple DBE',
         ],
       },
     };

--- a/hosting/apply/src/views/Sections/Declarations/Show.vue
+++ b/hosting/apply/src/views/Sections/Declarations/Show.vue
@@ -1,16 +1,18 @@
 <template>
   <section class="card mb-3">
     <div class="card-header">
-      <h3 class="card-title">Declarations</h3>
+      <h3 class="card-title">
+        Declarations
+      </h3>
     </div>
     <BooleanWithCheckboxes
-      changeLink="/apply/declarations"
+      change-link="/apply/declarations"
       :other="applicant.how_do_you_know_the_commissioners"
-      otherCaption="How do you know them?"
+      other-caption="How do you know them?"
       title="Are you related to, or known to any of the JAC Commissioners?"
-      :answeredYes="applicant.are_you_known_to_the_commissioners"
+      :answered-yes="applicant.are_you_known_to_the_commissioners"
       :records="applicant.known_to_commissioners"
-      />
+    />
   </section>
 </template>
 

--- a/hosting/apply/src/views/Sections/Diversity/Edit.vue
+++ b/hosting/apply/src/views/Sections/Diversity/Edit.vue
@@ -5,242 +5,391 @@
 
       <p>The JAC will use the information that you provide in 2 ways:</p>
       <ol>
-        <li>where the <a href="https://www.judicialappointments.gov.uk/equal-merit-provision" target="_blank">Equal Merit Provision policy</a> applies</li>
+        <li>
+          where the <a
+            href="https://www.judicialappointments.gov.uk/equal-merit-provision"
+            target="_blank"
+          >Equal Merit Provision policy</a> applies
+        </li>
         <li>to monitor the selection process</li>
       </ol>
-      <p>Find out <a href="https://www.judicialappointments.gov.uk/providing-diversity-information-jac" target="_blank">more information on the JAC website</a></p>
+      <p>
+        Find out <a
+          href="https://www.judicialappointments.gov.uk/providing-diversity-information-jac"
+          target="_blank"
+        >more information on the JAC website</a>
+      </p>
 
       <fieldset>
         <legend>Sharing my diversity data</legend>
-          <SelectList id="sharing_consent" :options="selectListOptions.sharingConsent" v-model="applicant.diversity_sharing_consent" />
+        <SelectList
+          id="sharing_consent"
+          v-model="applicant.diversity_sharing_consent"
+          :options="selectListOptions.sharingConsent"
+        />
       </fieldset>
 
       <fieldset>
         <legend>What is your professional background?</legend>
-        <div class="fieldset-text">Select all that apply</div>
-        <SelectList id="professional_background" :multiple="true" :options="selectListOptions.professionalBackground" v-model="applicant.professional_background" />
+        <div class="fieldset-text">
+          Select all that apply
+        </div>
+        <SelectList
+          id="professional_background"
+          v-model="applicant.professional_background"
+          :multiple="true"
+          :options="selectListOptions.professionalBackground"
+        />
         <div class="custom-control custom-checkbox">
-          <input class="custom-control-input" type="checkbox" id="professional_background_other" :value="true" v-model="applicant.professional_background_has_other">
-          <label class="custom-control-label" for="professional_background_other">
+          <input
+            id="professional_background_other"
+            v-model="applicant.professional_background_has_other"
+            class="custom-control-input"
+            type="checkbox"
+            :value="true"
+          >
+          <label
+            class="custom-control-label"
+            for="professional_background_other"
+          >
             Other (please specify)
           </label>
-          <input v-if="applicant.professional_background_has_other" type="text" class="form-control" v-model="applicant.professional_background_other">
+          <input
+            v-if="applicant.professional_background_has_other"
+            v-model="applicant.professional_background_other"
+            type="text"
+            class="form-control"
+          >
         </div>
       </fieldset>
 
       <fieldset>
         <legend>What is your current legal role?</legend>
-        <div class="fieldset-text">If you currently hold multiple roles, select all that apply</div>
-        <SelectList id="current_legal_role" :multiple="true" :options="selectListOptions.currentLegalRole" v-model="applicant.current_legal_role" />
+        <div class="fieldset-text">
+          If you currently hold multiple roles, select all that apply
+        </div>
+        <SelectList
+          id="current_legal_role"
+          v-model="applicant.current_legal_role"
+          :multiple="true"
+          :options="selectListOptions.currentLegalRole"
+        />
         <div class="custom-control custom-checkbox">
-          <input class="custom-control-input" type="checkbox" id="current_legal_role_other" :value="true" v-model="applicant.current_legal_role_has_other">
-          <label class="custom-control-label" for="current_legal_role_other">
+          <input
+            id="current_legal_role_other"
+            v-model="applicant.current_legal_role_has_other"
+            class="custom-control-input"
+            type="checkbox"
+            :value="true"
+          >
+          <label
+            class="custom-control-label"
+            for="current_legal_role_other"
+          >
             Other (please specify)
           </label>
-          <input v-if="applicant.current_legal_role_has_other" type="text" class="form-control" v-model="applicant.current_legal_role_other">
+          <input
+            v-if="applicant.current_legal_role_has_other"
+            v-model="applicant.current_legal_role_other"
+            type="text"
+            class="form-control"
+          >
         </div>
       </fieldset>
 
       <fieldset>
         <legend>Do you hold, or have you held in the past, a fee-paid judicial role?</legend>
-        <SelectList id="fee_paid_judicial_role" :options="selectListOptions.feePaidJudicialRole" v-model="applicant.fee_paid_judicial" />
+        <SelectList
+          id="fee_paid_judicial_role"
+          v-model="applicant.fee_paid_judicial"
+          :options="selectListOptions.feePaidJudicialRole"
+        />
       </fieldset>
 
       <fieldset>
         <legend>Between the ages 11 to 18, did you mainly attend a state or fee-paying school?</legend>
-        <SelectList id="school_type" :options="selectListOptions.schoolTypes" v-model="applicant.school_type" />
+        <SelectList
+          id="school_type"
+          v-model="applicant.school_type"
+          :options="selectListOptions.schoolTypes"
+        />
       </fieldset>
 
       <fieldset>
         <legend>Did you go to university and if so, were you the first generation from your family to go?</legend>
-        <SelectList id="university_attendance" :options="selectListOptions.universityAttendance" v-model="applicant.university_attendance" />
+        <SelectList
+          id="university_attendance"
+          v-model="applicant.university_attendance"
+          :options="selectListOptions.universityAttendance"
+        />
       </fieldset>
 
       <fieldset>
         <legend>What is your ethnic group?</legend>
-        <SelectList id="ethnicity_no_answer" :options="['Prefer not to answer']" v-model="applicant.ethnicity" />
-        <h6 class="mt-3">Asian/Asian British</h6>
-        <SelectList id="ethnicity_asian" :options="selectListOptions.ethnicities.asian" v-model="applicant.ethnicity" />
-        <h6 class="mt-3">Black/African/Caribbean/Black British</h6>
-        <SelectList id="ethnicity_black" :options="selectListOptions.ethnicities.black" v-model="applicant.ethnicity" />
-        <h6 class="mt-3">White</h6>
-        <SelectList id="ethnicity_white" :options="selectListOptions.ethnicities.white" v-model="applicant.ethnicity" />
-        <h6 class="mt-3">Mixed or multiple ethnic backgrounds</h6>
-        <SelectList id="ethnicity_mixed" :options="selectListOptions.ethnicities.mixed" v-model="applicant.ethnicity" />
-        <h6 class="mt-3">Other ethnic group</h6>
+        <SelectList
+          id="ethnicity_no_answer"
+          v-model="applicant.ethnicity"
+          :options="['Prefer not to answer']"
+        />
+        <h6 class="mt-3">
+          Asian/Asian British
+        </h6>
+        <SelectList
+          id="ethnicity_asian"
+          v-model="applicant.ethnicity"
+          :options="selectListOptions.ethnicities.asian"
+        />
+        <h6 class="mt-3">
+          Black/African/Caribbean/Black British
+        </h6>
+        <SelectList
+          id="ethnicity_black"
+          v-model="applicant.ethnicity"
+          :options="selectListOptions.ethnicities.black"
+        />
+        <h6 class="mt-3">
+          White
+        </h6>
+        <SelectList
+          id="ethnicity_white"
+          v-model="applicant.ethnicity"
+          :options="selectListOptions.ethnicities.white"
+        />
+        <h6 class="mt-3">
+          Mixed or multiple ethnic backgrounds
+        </h6>
+        <SelectList
+          id="ethnicity_mixed"
+          v-model="applicant.ethnicity"
+          :options="selectListOptions.ethnicities.mixed"
+        />
+        <h6 class="mt-3">
+          Other ethnic group
+        </h6>
         <div class="custom-control custom-radio">
-          <input class="custom-control-input" type="radio" id="ethnicicty_other" value="Other" v-model="applicant.ethnicity">
-          <label class="custom-control-label" for="ethnicicty_other">
+          <input
+            id="ethnicicty_other"
+            v-model="applicant.ethnicity"
+            class="custom-control-input"
+            type="radio"
+            value="Other"
+          >
+          <label
+            class="custom-control-label"
+            for="ethnicicty_other"
+          >
             Other (please specify)
           </label>
-          <input v-if="applicant.ethnicity === 'Other'" type="text" class="form-control" v-model="applicant.ethnicity_other">
+          <input
+            v-if="applicant.ethnicity === 'Other'"
+            v-model="applicant.ethnicity_other"
+            type="text"
+            class="form-control"
+          >
         </div>
       </fieldset>
 
       <fieldset>
         <legend>What is your gender?</legend>
-        <SelectList id="gender" :options="selectListOptions.gender" v-model="applicant.gender" />
+        <SelectList
+          id="gender"
+          v-model="applicant.gender"
+          :options="selectListOptions.gender"
+        />
       </fieldset>
 
       <fieldset>
         <legend>Is your gender identity the same as the gender you were assigned at birth?</legend>
-        <SelectList id="gender_same_as_birth" :options="selectListOptions.yesNo" v-model="applicant.gender_same_as_birth" />
+        <SelectList
+          id="gender_same_as_birth"
+          v-model="applicant.gender_same_as_birth"
+          :options="selectListOptions.yesNo"
+        />
       </fieldset>
 
       <fieldset>
         <legend>How would you describe your sexual orientation?</legend>
-        <SelectList id="sexual_orientation" :options="selectListOptions.sexualOrientation" v-model="applicant.sexual_orientation" />
+        <SelectList
+          id="sexual_orientation"
+          v-model="applicant.sexual_orientation"
+          :options="selectListOptions.sexualOrientation"
+        />
       </fieldset>
 
       <fieldset>
         <legend>Do you have a disability, as defined by the Equality Act 2010?</legend>
-        <SelectList id="disability" :options="selectListOptions.yesNo" v-model="applicant.disability" />
+        <SelectList
+          id="disability"
+          v-model="applicant.disability"
+          :options="selectListOptions.yesNo"
+        />
       </fieldset>
 
       <fieldset>
         <legend>What is your religion or belief?</legend>
-        <SelectList id="religion" :options="selectListOptions.religion" v-model="applicant.religion" />
+        <SelectList
+          id="religion"
+          v-model="applicant.religion"
+          :options="selectListOptions.religion"
+        />
         <div class="custom-control custom-radio">
-          <input class="custom-control-input" type="radio" id="religion_other" value="Other" v-model="applicant.religion">
-          <label class="custom-control-label" for="religion_other">
+          <input
+            id="religion_other"
+            v-model="applicant.religion"
+            class="custom-control-input"
+            type="radio"
+            value="Other"
+          >
+          <label
+            class="custom-control-label"
+            for="religion_other"
+          >
             Other (please specify)
           </label>
-          <input v-if="applicant.religion === 'Other'" type="text" class="form-control" v-model="applicant.religion_other">
+          <input
+            v-if="applicant.religion === 'Other'"
+            v-model="applicant.religion_other"
+            type="text"
+            class="form-control"
+          >
         </div>
       </fieldset>
 
-      <SaveAndContinueButtons :isSaving="isSaving" @saveAndContinue="saveAndContinue" />
+      <SaveAndContinueButtons
+        :is-saving="isSaving"
+        @saveAndContinue="saveAndContinue"
+      />
     </form>
   </section>
 </template>
 
 <script>
-  import SelectList from '@/components/SelectList';
-  import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
+import SelectList from '@/components/SelectList';
+import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
 
-  export default {
-    components: {
-      SaveAndContinueButtons,
-      SelectList,
-    },
-    data() {
-      return {
-        applicant: this.$store.getters.applicant(),
-        isSaving: false,
-        selectListOptions: {
-          sharingConsent: [
-            {value: true, label: 'You may share my diversity data with the Ministry of Justice, Judicial Office and HM Courts and Tribunals Service (for monitoring purposes only)',},
-            {value: false, label: 'Do NOT share my diversity data',}
+export default {
+  components: {
+    SaveAndContinueButtons,
+    SelectList,
+  },
+  data() {
+    return {
+      applicant: this.$store.getters.applicant(),
+      isSaving: false,
+      selectListOptions: {
+        sharingConsent: [
+          {value: true, label: 'You may share my diversity data with the Ministry of Justice, Judicial Office and HM Courts and Tribunals Service (for monitoring purposes only)'},
+          {value: false, label: 'Do NOT share my diversity data'},
+        ],
+        professionalBackground: [
+          'Barrister',
+          'CILEx',
+          'Solicitor',
+          'Prefer not to answer',
+        ],
+        currentLegalRole: [
+          'Academic',
+          'Barrister',
+          'Fee-paid court judge',
+          'Fee-paid tribunal judge',
+          'Fellow of CILEx',
+          'Other fee-paid judicial office holder',
+          'Other salaried judicial office holder',
+          'Salaried court judge',
+          'Salaried tribunal judge',
+          'Solicitor',
+          'Prefer not to answer',
+        ],
+        feePaidJudicialRole: [
+          'Fee-paid court post',
+          'Fee-paid tribunal post',
+          'I have not previously held a fee-paid role',
+          'Other fee-paid judicial office',
+          'Prefer not to answer',
+        ],
+        schoolTypes: [
+          'UK state school – selective',
+          'UK state school – non-selective',
+          'UK independent or fee-paying school',
+          'UK independent or fee-paying school with financial assistance (bursary or means-tested scholarship)',
+          'I attended a school outside of the UK',
+          'Prefer not to answer',
+        ],
+        universityAttendance: [
+          'I did not go to university',
+          'I went to university and was the first generation in my family to do so',
+          'I went to university but was not first generation in my family to do so',
+          'Prefer not to answer',
+        ],
+        ethnicities: {
+          asian: [
+            'Bangladeshi',
+            'Chinese',
+            'Indian',
+            'Pakistani',
+            'Any other Asian background',
           ],
-          professionalBackground: [
-            'Barrister',
-            'CILEx',
-            'Solicitor',
-            'Prefer not to answer'
+          black: [
+            'African',
+            'Caribbean',
+            'Any other Black/African/Caribbean background',
           ],
-          currentLegalRole: [
-            'Academic',
-            'Barrister',
-            'Fee-paid court judge',
-            'Fee-paid tribunal judge',
-            'Fellow of CILEx',
-            'Other fee-paid judicial office holder',
-            'Other salaried judicial office holder',
-            'Salaried court judge',
-            'Salaried tribunal judge',
-            'Solicitor',
-            'Prefer not to answer'
+          white: [
+            'English, Welsh, Scottish, Northern Ireland, British',
+            'Irish',
+            'Gypsy or Irish Traveller',
+            'Any other White background',
           ],
-          feePaidJudicialRole: [
-            'Fee-paid court post',
-            'Fee-paid tribunal post',
-            'I have not previously held a fee-paid role',
-            'Other fee-paid judicial office',
-            'Prefer not to answer'
-          ],
-          schoolTypes: [
-            'UK state school – selective',
-            'UK state school – non-selective',
-            'UK independent or fee-paying school',
-            'UK independent or fee-paying school with financial assistance (bursary or means-tested scholarship)',
-            'I attended a school outside of the UK',
-            'Prefer not to answer'
-          ],
-          universityAttendance: [
-            'I did not go to university',
-            'I went to university and was the first generation in my family to do so',
-            'I went to university but was not first generation in my family to do so',
-            'Prefer not to answer'
-          ],
-          ethnicities: {
-            asian: [
-              'Bangladeshi',
-              'Chinese',
-              'Indian',
-              'Pakistani',
-              'Any other Asian background'
-            ],
-            black: [
-              'African',
-              'Caribbean',
-              'Any other Black/African/Caribbean background'
-            ],
-            white: [
-              'English, Welsh, Scottish, Northern Ireland, British',
-              'Irish',
-              'Gypsy or Irish Traveller',
-              'Any other White background'
-            ],
-            mixed: [
-              'White and Black Caribbean',
-              'White and Black African',
-              'White and Asian',
-              'Any other mixed or multiple ethnic background'
-            ],
-          },
-          gender: [
-            'Female',
-            'Male',
-            'Other',
-            'Prefer not to answer'
-          ],
-          yesNo: [
-            'Yes',
-            'No',
-            'Prefer not to answer'
-          ],
-          sexualOrientation: [
-            'Bisexual',
-            'Gay man',
-            'Gay woman/ lesbian',
-            'Heterosexual/ straight',
-            'Other',
-            'Prefer not to answer'
-          ],
-          religion: [
-            'Atheist',
-            'Buddhist',
-            'Christian',
-            'Hindu',
-            'Jewish',
-            'Muslim',
-            'No religion',
-            'Sikh',
-            'Prefer not to answer'
+          mixed: [
+            'White and Black Caribbean',
+            'White and Black African',
+            'White and Asian',
+            'Any other mixed or multiple ethnic background',
           ],
         },
-      };
-    },
-    methods: {
-      async saveAndContinue() {
-        await this.save();
-        this.$emit('continue');
+        gender: [
+          'Female',
+          'Male',
+          'Other',
+          'Prefer not to answer',
+        ],
+        yesNo: [
+          'Yes',
+          'No',
+          'Prefer not to answer',
+        ],
+        sexualOrientation: [
+          'Bisexual',
+          'Gay man',
+          'Gay woman/ lesbian',
+          'Heterosexual/ straight',
+          'Other',
+          'Prefer not to answer',
+        ],
+        religion: [
+          'Atheist',
+          'Buddhist',
+          'Christian',
+          'Hindu',
+          'Jewish',
+          'Muslim',
+          'No religion',
+          'Sikh',
+          'Prefer not to answer',
+        ],
       },
-      async save() {
-        this.isSaving = true;
-        await this.$store.dispatch('saveApplicant', this.applicant);
-        this.isSaving = false;
-      },
+    };
+  },
+  methods: {
+    async saveAndContinue() {
+      await this.save();
+      this.$emit('continue');
     },
-  };
+    async save() {
+      this.isSaving = true;
+      await this.$store.dispatch('saveApplicant', this.applicant);
+      this.isSaving = false;
+    },
+  },
+};
 </script>

--- a/hosting/apply/src/views/Sections/Diversity/Show.vue
+++ b/hosting/apply/src/views/Sections/Diversity/Show.vue
@@ -1,7 +1,9 @@
 <template>
   <section class="card mb-3">
     <div class="card-header">
-      <h2 class="card-title">Diversity</h2>
+      <h2 class="card-title">
+        Diversity
+      </h2>
     </div>
     <div class="card-body">
       <table class="table mb-3">
@@ -22,83 +24,87 @@
         </tr>
         <tr>
           <td>
-            <RouterLink to="/apply/diversity" class="float-right">Change</RouterLink>
+            <RouterLink
+              to="/apply/diversity"
+              class="float-right"
+            >
+              Change
+            </RouterLink>
           </td>
         </tr>
       </table>
 
       <ShowSelectList
-        changeLink="/apply/diversity"
-        :hasOther="applicant.professional_background_has_other"
+        change-link="/apply/diversity"
+        :has-other="applicant.professional_background_has_other"
         :other="applicant.professional_background_other"
         title="What is your professional background?"
         :records="applicant.professional_background"
-        />
+      />
 
       <ShowSelectList
-        changeLink="/apply/diversity"
-        :hasOther="applicant.current_legal_role_has_other"
+        change-link="/apply/diversity"
+        :has-other="applicant.current_legal_role_has_other"
         :other="applicant.current_legal_role_other"
         title="What is your current legal role?"
         :records="applicant.current_legal_role"
-        />
+      />
 
       <ShowSelectList
-        changeLink="/apply/diversity"
+        change-link="/apply/diversity"
         title="Do you hold, or have you held in the past, a fee-paid judicial role?"
-        :singleResponse ="applicant.fee_paid_judicial"
-        />
+        :single-response="applicant.fee_paid_judicial"
+      />
 
       <ShowSelectList
-        changeLink="/apply/diversity"
+        change-link="/apply/diversity"
         title="Between the ages 11 to 18, did you mainly attend a state or fee-paying school?"
-        :singleResponse ="applicant.school_type"
-        />
+        :single-response="applicant.school_type"
+      />
 
       <ShowSelectList
-        changeLink="/apply/diversity"
+        change-link="/apply/diversity"
         title="Did you go to university and if so, were you the first generation from your family to go?"
-        :singleResponse ="applicant.university_attendance"
-        />
+        :single-response="applicant.university_attendance"
+      />
 
       <ShowSelectList
-        changeLink="/apply/diversity"
+        change-link="/apply/diversity"
         title="What is your ethnic group?"
         :other="applicant.ethnicity_other"
-        :singleResponse ="applicant.ethnicity"
-        />
+        :single-response="applicant.ethnicity"
+      />
 
       <ShowSelectList
-        changeLink="/apply/diversity"
+        change-link="/apply/diversity"
         title="What is your gender?"
-        :singleResponse ="applicant.gender"
-        />
+        :single-response="applicant.gender"
+      />
 
       <ShowSelectList
-        changeLink="/apply/diversity"
+        change-link="/apply/diversity"
         title="Is your gender identity the same as the gender you were assigned at birth?"
-        :singleResponse ="applicant.gender_same_as_birth"
-        />
+        :single-response="applicant.gender_same_as_birth"
+      />
 
       <ShowSelectList
-        changeLink="/apply/diversity"
+        change-link="/apply/diversity"
         title="How would you describe your sexual orientation?"
-        :singleResponse ="applicant.sexual_orientation"
-        />
+        :single-response="applicant.sexual_orientation"
+      />
 
       <ShowSelectList
-        changeLink="/apply/diversity"
+        change-link="/apply/diversity"
         title="Do you have a disability, as defined by the Equality Act 2010?"
-        :singleResponse ="applicant.disability"
-        />
+        :single-response="applicant.disability"
+      />
 
       <ShowSelectList
-        changeLink="/apply/diversity"
+        change-link="/apply/diversity"
         title="What is your religion or belief?"
         :other="applicant.religion_other"
-        :singleResponse ="applicant.religion"
-        />
-
+        :single-response="applicant.religion"
+      />
     </div>
   </section>
 </template>

--- a/hosting/apply/src/views/Sections/Experience/Edit.vue
+++ b/hosting/apply/src/views/Sections/Experience/Edit.vue
@@ -8,74 +8,103 @@
         <div class="fieldset-text">
           List your employment history, including any judicial appointments, starting with your most recent job
         </div>
-        <RepeatableFields v-model="applicant.experience" :component="repeatableFields.Experience" />
+        <RepeatableFields
+          v-model="applicant.experience"
+          :component="repeatableFields.Experience"
+        />
       </fieldset>
 
       <fieldset>
         <legend>Have you had any gaps in employment since you qualified?</legend>
         <BooleanInput v-model="applicant.has_gaps_in_employment" />
-        <div v-if="applicant.has_gaps_in_employment" class="mt-3">
+        <div
+          v-if="applicant.has_gaps_in_employment"
+          class="mt-3"
+        >
           <label>What law-related activities did you do during this time, if any?</label>
-          <div class="fieldset-text">Select all that apply</div>
-          <SelectList :multiple="true" :options="selectListOptions.activities" v-model="applicant.gaps_in_employment_activities" id="gaps_in_employment_activities" />
+          <div class="fieldset-text">
+            Select all that apply
+          </div>
+          <SelectList
+            id="gaps_in_employment_activities"
+            v-model="applicant.gaps_in_employment_activities"
+            :multiple="true"
+            :options="selectListOptions.activities"
+          />
           <div class="custom-control custom-checkbox">
-            <input type="checkbox" class="custom-control-input" id="gaps_in_employment_activities_other" v-model="applicant.gaps_in_employment_activities_has_other">
-            <label class="custom-control-label" for="gaps_in_employment_activities_other">Other activity that may be considered law-related</label>
-            <input v-if="applicant.gaps_in_employment_activities_has_other" type="text" class="form-control" v-model="applicant.gaps_in_employment_activities_other">
+            <input
+              id="gaps_in_employment_activities_other"
+              v-model="applicant.gaps_in_employment_activities_has_other"
+              type="checkbox"
+              class="custom-control-input"
+            >
+            <label
+              class="custom-control-label"
+              for="gaps_in_employment_activities_other"
+            >Other activity that may be considered law-related</label>
+            <input
+              v-if="applicant.gaps_in_employment_activities_has_other"
+              v-model="applicant.gaps_in_employment_activities_other"
+              type="text"
+              class="form-control"
+            >
           </div>
         </div>
       </fieldset>
 
-      <SaveAndContinueButtons :isSaving="isSaving" @saveAndContinue="saveAndContinue" />
+      <SaveAndContinueButtons
+        :is-saving="isSaving"
+        @saveAndContinue="saveAndContinue"
+      />
     </form>
   </section>
 </template>
 
 <script>
-  import BooleanInput from '@/components/BooleanInput';
-  import RepeatableFields from '@/components/RepeatableFields';
-  import SelectList from '@/components/SelectList';
-  import Experience from '@/views/RepeatableFields/Experience';
-  import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
+import BooleanInput from '@/components/BooleanInput';
+import RepeatableFields from '@/components/RepeatableFields';
+import SelectList from '@/components/SelectList';
+import Experience from '@/views/RepeatableFields/Experience';
+import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
 
-  export default {
-    components: {
-      SaveAndContinueButtons,
-      BooleanInput,
-      RepeatableFields,
-      SelectList,
-    },
-    data() {
-      return {
-        applicant: this.$store.getters.applicant(),
-        isSaving: false,
-        selectListOptions: {
-          activities: [
-            'Carrying out of judicial functions of any court or tribunals',
-            'Acting as an arbitrator',
-            'Practising or being employed as a lawyer',
-            'Advising (whether or not in the course of such practice or employment as a lawyer) on the application of the law',
-            'Assisting (whether or not in the course of such practice) persons involved in proceedings for the resolution of issues arising under the law',
-            'Acting (whether or not in the course of such practice) as a mediator in connection with attempts to resolve issues that are the subject of proceedings or could be, if not resolved',
-            'Drafting (whether or not in the course of such practice) documents intended to affect persons’ rights and obligations',
-            'Teaching or researching law'
-          ],
-        },
-        repeatableFields: {
-          Experience,
-        },
-      };
-    },
-    methods: {
-      async saveAndContinue() {
-        await this.save();
-        this.$emit('continue');
+export default {
+  components: {
+    SaveAndContinueButtons,
+    BooleanInput,
+    RepeatableFields,
+    SelectList,
+  },
+  data() {
+    return {
+      applicant: this.$store.getters.applicant(),
+      isSaving: false,
+      selectListOptions: {
+        activities: [
+          'Carrying out of judicial functions of any court or tribunals',
+          'Acting as an arbitrator',
+          'Practising or being employed as a lawyer',
+          'Advising (whether or not in the course of such practice or employment as a lawyer) on the application of the law',
+          'Assisting (whether or not in the course of such practice) persons involved in proceedings for the resolution of issues arising under the law',
+          'Acting (whether or not in the course of such practice) as a mediator in connection with attempts to resolve issues that are the subject of proceedings or could be, if not resolved',
+          'Drafting (whether or not in the course of such practice) documents intended to affect persons’ rights and obligations',
+          'Teaching or researching law',
+        ],
       },
-      async save() {
-        this.isSaving = true;
-        await this.$store.dispatch('saveApplicant', this.applicant);
-        this.isSaving = false;
+      repeatableFields: {
+        Experience,
       },
+    };
+  },
+  methods: {
+    async saveAndContinue() {
+      await this.save();
+      this.$emit('continue');
     },
-  };
+    async save() {
+      this.isSaving = true;
+      await this.$store.dispatch('saveApplicant', this.applicant);
+      this.isSaving = false;
+    },
+  },
+};
 </script>

--- a/hosting/apply/src/views/Sections/Experience/Show.vue
+++ b/hosting/apply/src/views/Sections/Experience/Show.vue
@@ -1,83 +1,127 @@
 <template>
   <section class="card mb-3">
     <div class="card-header">
-      <h3 class="card-title">Experience</h3>
+      <h3 class="card-title">
+        Experience
+      </h3>
     </div>
 
     <div class="card-body">
-      <table class="table mb-3" v-for="exp in applicant.experience" :key="exp.title">
+      <table
+        v-for="exp in applicant.experience"
+        :key="exp.title"
+        class="table mb-3"
+      >
         <tbody>
           <tr>
-            <th scope="row">Title</th>
+            <th scope="row">
+              Title
+            </th>
             <td>{{ exp.title }}</td>
           </tr>
           <tr>
-            <th scope="row">Date from</th>
+            <th scope="row">
+              Date from
+            </th>
             <td>{{ exp.date_from.toLocaleDateString() }}</td>
           </tr>
           <tr>
-            <th scope="row">Date to</th>
-            <td v-if="exp.currently_in_job">I currently work in this job</td>
-            <td v-else>{{ exp.date_to.toLocaleDateString() }}</td>
+            <th scope="row">
+              Date to
+            </th>
+            <td v-if="exp.currently_in_job">
+              I currently work in this job
+            </td>
+            <td v-else>
+              {{ exp.date_to.toLocaleDateString() }}
+            </td>
           </tr>
           <tr>
-            <th scope="row">Judicial appointment?</th>
+            <th scope="row">
+              Judicial appointment?
+            </th>
             <td>{{ exp.is_judicial_appointment ? 'Yes' : 'No' }}</td>
           </tr>
         </tbody>
         <tbody v-if="exp.is_judicial_appointment">
           <tr>
-            <th scope="row">Salaried or fee-paid?</th>
+            <th scope="row">
+              Salaried or fee-paid?
+            </th>
             <td>{{ exp.appointment_type }}</td>
           </tr>
           <tr>
-            <th scope="row">Jurisdiction</th>
+            <th scope="row">
+              Jurisdiction
+            </th>
             <td>{{ exp.jurisdiction }}</td>
           </tr>
           <tr>
-            <th scope="row">Circuit</th>
+            <th scope="row">
+              Circuit
+            </th>
             <td>{{ exp.circuit }}</td>
           </tr>
           <tr>
-            <th scope="row">Days sat in appointment</th>
+            <th scope="row">
+              Days sat in appointment
+            </th>
             <td>{{ exp.days_sat }}</td>
           </tr>
         </tbody>
         <tbody v-if="!exp.is_judicial_appointment">
           <tr>
-            <th scope="row">In Government Legal Service or Crown Prosecution Service?</th>
+            <th scope="row">
+              In Government Legal Service or Crown Prosecution Service?
+            </th>
             <td>{{ exp.is_public_employee ? 'Yes' : 'No' }}</td>
           </tr>
           <tr>
-            <th scope="row">Company or organisation</th>
+            <th scope="row">
+              Company or organisation
+            </th>
             <td>{{ exp.company }}</td>
           </tr>
           <tr>
-            <th scope="row">Law-related activities</th>
+            <th scope="row">
+              Law-related activities
+            </th>
             <td>
               <ul>
-                <li v-for="activity in exp.activities" :key="activity">
+                <li
+                  v-for="activity in exp.activities"
+                  :key="activity"
+                >
                   {{ activity }}
                 </li>
                 <li v-if="exp.activities_has_other">
-                  Other: {{exp.activities_other}}
+                  Other: {{ exp.activities_other }}
                 </li>
               </ul>
             </td>
           </tr>
           <tr>
-            <th scope="row">Main duties</th>
+            <th scope="row">
+              Main duties
+            </th>
             <td>{{ exp.main_duties }}</td>
           </tr>
           <tr>
-            <th scope="row">Specialism/s</th>
+            <th scope="row">
+              Specialism/s
+            </th>
             <td>{{ exp.specialisms }}</td>
           </tr>
         </tbody>
         <tfoot>
           <tr>
             <td colspan="2">
-              <RouterLink to="/apply/experience" class="float-right">Change</RouterLink>
+              <RouterLink
+                to="/apply/experience"
+                class="float-right"
+              >
+                Change
+              </RouterLink>
             </td>
           </tr>
         </tfoot>
@@ -86,26 +130,37 @@
       <table class="table">
         <tbody>
           <tr>
-            <th scope="row">Have you had and gaps in employment?</th>
+            <th scope="row">
+              Have you had and gaps in employment?
+            </th>
             <td>{{ applicant.has_gaps_in_employment ? "Yes" : "No" }}</td>
             <td>
-              <RouterLink to="/apply/experience">Change</RouterLink>
+              <RouterLink to="/apply/experience">
+                Change
+              </RouterLink>
             </td>
           </tr>
           <tr>
-            <th scope="row">Law-related activities during gaps</th>
+            <th scope="row">
+              Law-related activities during gaps
+            </th>
             <td>
               <ul>
-                <li v-for="activity in applicant.gaps_in_employment_activities" :key="activity">
+                <li
+                  v-for="activity in applicant.gaps_in_employment_activities"
+                  :key="activity"
+                >
                   {{ activity }}
                 </li>
                 <li v-if="applicant.gaps_in_employment_activities_has_other">
-                  Other: {{applicant.gaps_in_employment_activities_other}}
+                  Other: {{ applicant.gaps_in_employment_activities_other }}
                 </li>
               </ul>
             </td>
             <td>
-              <RouterLink to="/apply/experience">Change</RouterLink>
+              <RouterLink to="/apply/experience">
+                Change
+              </RouterLink>
             </td>
           </tr>
         </tbody>

--- a/hosting/apply/src/views/Sections/Introduction/Edit.vue
+++ b/hosting/apply/src/views/Sections/Introduction/Edit.vue
@@ -2,18 +2,30 @@
   <section>
     <form @submit.prevent="save">
       <h2>Introduction</h2>
-      <p>You are applying for <strong>{{vacancy.jac_ref}}: {{vacancy.title}}</strong></p>
+      <p>You are applying for <strong>{{ vacancy.jac_ref }}: {{ vacancy.title }}</strong></p>
 
       <fieldset>
         <legend>Confidentiality</legend>
-        <SelectList id="confidentiality" :multiple="true" :options="selectListOptions.confidentiality" v-model="applicant.confidentiality" />
+        <SelectList
+          id="confidentiality"
+          v-model="applicant.confidentiality"
+          :multiple="true"
+          :options="selectListOptions.confidentiality"
+        />
       </fieldset>
 
       <div class="form-actions">
-        <button class="btn btn-primary mr-2" type="button" @click.prevent="saveAndContinue">
+        <button
+          class="btn btn-primary mr-2"
+          type="button"
+          @click.prevent="saveAndContinue"
+        >
           Start application
         </button>
-        <span class="spinner-border spinner-border-sm text-secondary" v-if="isSaving"></span>
+        <span
+          v-if="isSaving"
+          class="spinner-border spinner-border-sm text-secondary"
+        />
       </div>
     </form>
   </section>
@@ -36,7 +48,7 @@ export default {
           'I undertake to maintain absolute confidentiality relating to all aspects of the selection process for this selection exercise.',
           'As I progress in the exercise I undertake to ensure that any relevant materials provided to me as part of the selection process are kept secure and not shared with anyone else.',
           'I understand that the Judicial Appointments Commission will automatically refer any suspected breach of this agreement to the Bar Standards Board, the Solicitors Regulatory Authority, CILEx Regulation, Judicial Conduct Investigations Office or other relevant regulatory body to consider as a potential breach of my professional obligations, or as misconduct, and this could result in disciplinary action by my regulator.',
-          'I understand that the Judicial Appointments Commission takes very seriously the integrity of the selection process and any evidence that a candidate has breached this agreement might result in disqualification from this and future exercises.'
+          'I understand that the Judicial Appointments Commission takes very seriously the integrity of the selection process and any evidence that a candidate has breached this agreement might result in disqualification from this and future exercises.',
         ],
       },
     };

--- a/hosting/apply/src/views/Sections/Outreach/Edit.vue
+++ b/hosting/apply/src/views/Sections/Outreach/Edit.vue
@@ -1,17 +1,37 @@
 <template>
   <section>
     <form @submit.prevent="save">
-
       <fieldset>
         <legend>How did you hear about this vacancy?</legend>
-        <div class="fieldset-text">Select all that apply</div>
-        <SelectList id="how_did_you_hear" :multiple="true" :options="selectListOptions.heard_about_from" v-model="applicant.how_did_you_hear" />
+        <div class="fieldset-text">
+          Select all that apply
+        </div>
+        <SelectList
+          id="how_did_you_hear"
+          v-model="applicant.how_did_you_hear"
+          :multiple="true"
+          :options="selectListOptions.heard_about_from"
+        />
         <div class="custom-control custom-checkbox">
-          <input class="custom-control-input" type="checkbox" id="how_did_you_hear_has_other" :value="true" v-model="applicant.how_did_you_hear_has_other">
-          <label class="custom-control-label" for="how_did_you_hear_has_other">
+          <input
+            id="how_did_you_hear_has_other"
+            v-model="applicant.how_did_you_hear_has_other"
+            class="custom-control-input"
+            type="checkbox"
+            :value="true"
+          >
+          <label
+            class="custom-control-label"
+            for="how_did_you_hear_has_other"
+          >
             Other form of communication (please specify)
           </label>
-          <input v-if="applicant.how_did_you_hear_has_other" type="text" class="form-control" v-model="applicant.how_did_you_hear_other">
+          <input
+            v-if="applicant.how_did_you_hear_has_other"
+            v-model="applicant.how_did_you_hear_other"
+            type="text"
+            class="form-control"
+          >
         </div>
       </fieldset>
 
@@ -25,7 +45,10 @@
         <BooleanInput v-model="applicant.taken_part_in_judicial_work_shadowing_scheme" />
       </fieldset>
 
-      <SaveAndContinueButtons :isSaving="isSaving" @saveAndContinue="saveAndContinue" />
+      <SaveAndContinueButtons
+        :is-saving="isSaving"
+        @saveAndContinue="saveAndContinue"
+      />
     </form>
   </section>
 </template>
@@ -54,7 +77,7 @@ export default {
           'Twitter',
           'LinkedIn',
           'Word of mouth',
-          'From one of the presiding judges'
+          'From one of the presiding judges',
         ],
       },
     };

--- a/hosting/apply/src/views/Sections/Outreach/Show.vue
+++ b/hosting/apply/src/views/Sections/Outreach/Show.vue
@@ -1,24 +1,29 @@
 <template>
   <section class="card mb-3">
     <div class="card-header">
-      <h2 class="card-title">Outreach</h2>
+      <h2 class="card-title">
+        Outreach
+      </h2>
     </div>
     <div class="card-body">
-
       <ShowSelectList
-        changeLink="/apply/outreach"
-        :hasOther="applicant.how_did_you_hear_has_other"
+        change-link="/apply/outreach"
+        :has-other="applicant.how_did_you_hear_has_other"
         title="How did you hear about this vacancy?"
         :records="applicant.how_did_you_hear"
-        />
+      />
 
       <table class="table">
         <tbody>
           <tr>
-            <th scope="row">Have you attended an outreach event on JAC selection exercises?</th>
+            <th scope="row">
+              Have you attended an outreach event on JAC selection exercises?
+            </th>
             <td>{{ applicant.has_attended_outreach_event ? "Yes" : "No" }}</td>
             <td>
-              <RouterLink to="/apply/outreach">Change</RouterLink>
+              <RouterLink to="/apply/outreach">
+                Change
+              </RouterLink>
             </td>
           </tr>
         </tbody>
@@ -27,15 +32,18 @@
       <table class="table">
         <tbody>
           <tr>
-            <th scope="row">Have you taken part in the Judicial Work Shadowing Scheme?</th>
+            <th scope="row">
+              Have you taken part in the Judicial Work Shadowing Scheme?
+            </th>
             <td>{{ applicant.taken_part_in_judicial_work_shadowing_scheme ? "Yes" : "No" }}</td>
             <td>
-              <RouterLink to="/apply/outreach">Change</RouterLink>
+              <RouterLink to="/apply/outreach">
+                Change
+              </RouterLink>
             </td>
           </tr>
         </tbody>
       </table>
-      
     </div>
   </section>
 </template>

--- a/hosting/apply/src/views/Sections/Personal/Edit.vue
+++ b/hosting/apply/src/views/Sections/Personal/Edit.vue
@@ -7,17 +7,35 @@
         <legend>Your name</legend>
         <div class="form-group">
           <label for="full_name">Full name</label>
-          <div class="fieldset-text">We’ll use this name when contacting you about your application, and when contacting your assessors</div>
-          <input type="text" class="form-control" id="full_name" v-model="applicant.full_name" autocomplete="name">
+          <div class="fieldset-text">
+            We’ll use this name when contacting you about your application, and when contacting your assessors
+          </div>
+          <input
+            id="full_name"
+            v-model="applicant.full_name"
+            type="text"
+            class="form-control"
+            autocomplete="name"
+          >
         </div>
         <div class="form-group">
           <label>Are you or have you been known by any other name?</label>
-          <div class="fieldset-text">We need this to do a character check</div>
+          <div class="fieldset-text">
+            We need this to do a character check
+          </div>
           <BooleanInput v-model="applicant.has_other_name" />
         </div>
-        <div class="form-group" v-if="applicant.has_other_name">
+        <div
+          v-if="applicant.has_other_name"
+          class="form-group"
+        >
           <label for="other_name">Name</label>
-          <input type="text" class="form-control" id="other_name" v-model="applicant.other_name">
+          <input
+            id="other_name"
+            v-model="applicant.other_name"
+            type="text"
+            class="form-control"
+          >
         </div>
       </fieldset>
 
@@ -36,7 +54,12 @@
         </div>
         <div class="form-group">
           <label for="national_insurance">National Insurance number</label>
-          <input type="text" class="form-control" id="national_insurance" v-model="applicant.national_insurance">
+          <input
+            id="national_insurance"
+            v-model="applicant.national_insurance"
+            type="text"
+            class="form-control"
+          >
         </div>
       </fieldset>
 
@@ -47,7 +70,13 @@
         </div>
         <div class="form-group">
           <label for="phone">Telephone number</label>
-          <input type="tel" class="form-control" id="phone" v-model="applicant.phone" autocomplete="tel">
+          <input
+            id="phone"
+            v-model="applicant.phone"
+            type="tel"
+            class="form-control"
+            autocomplete="tel"
+          >
         </div>
       </fieldset>
 
@@ -61,31 +90,67 @@
             Address
             <span class="sr-only">line 1 of 2</span>
           </label>
-          <input type="text" class="form-control" id="address_line_1" v-model="applicant.address_line_1" autocomplete="address-line1">
+          <input
+            id="address_line_1"
+            v-model="applicant.address_line_1"
+            type="text"
+            class="form-control"
+            autocomplete="address-line1"
+          >
         </div>
         <div class="form-group">
-          <label for="address_line_2" class="sr-only">
+          <label
+            for="address_line_2"
+            class="sr-only"
+          >
             Address line 2 of 2
           </label>
-          <input type="text" class="form-control" id="address_line_2" v-model="applicant.address_line_2" autocomplete="address-line2">
+          <input
+            id="address_line_2"
+            v-model="applicant.address_line_2"
+            type="text"
+            class="form-control"
+            autocomplete="address-line2"
+          >
         </div>
         <div class="form-group">
           <label for="address_town">
             Town or city
           </label>
-          <input type="text" class="form-control" id="address_town" v-model="applicant.address_town" autocomplete="address-line2" style="max-width: 18rem;">
+          <input
+            id="address_town"
+            v-model="applicant.address_town"
+            type="text"
+            class="form-control"
+            autocomplete="address-line2"
+            style="max-width: 18rem;"
+          >
         </div>
         <div class="form-group">
           <label for="address_county">
             County
           </label>
-          <input type="text" class="form-control" id="address_county" v-model="applicant.address_county" autocomplete="address-level1" style="max-width: 18rem;">
+          <input
+            id="address_county"
+            v-model="applicant.address_county"
+            type="text"
+            class="form-control"
+            autocomplete="address-level1"
+            style="max-width: 18rem;"
+          >
         </div>
         <div class="form-group">
           <label for="address_postcode">
             Postcode
           </label>
-          <input type="text" class="form-control" id="address_postcode" v-model="applicant.address_postcode" autocomplete="postal-code" style="max-width: 12rem;">
+          <input
+            id="address_postcode"
+            v-model="applicant.address_postcode"
+            type="text"
+            class="form-control"
+            autocomplete="postal-code"
+            style="max-width: 12rem;"
+          >
         </div>
       </fieldset>
 
@@ -98,23 +163,49 @@
         <p>Do you need any reasonable adjustments?</p>
 
         <div class="custom-control custom-radio custom-control-inline">
-          <input class="custom-control-input" type="radio" id="reasonable_adjustments_yes" :value="true" v-model="applicant.reasonable_adjustments">
-          <label class="custom-control-label" for="reasonable_adjustments_yes">
+          <input
+            id="reasonable_adjustments_yes"
+            v-model="applicant.reasonable_adjustments"
+            class="custom-control-input"
+            type="radio"
+            :value="true"
+          >
+          <label
+            class="custom-control-label"
+            for="reasonable_adjustments_yes"
+          >
             Yes
           </label>
         </div>
         <div class="custom-control custom-radio custom-control-inline">
-          <input class="custom-control-input" type="radio" id="reasonable_adjustments_no" :value="false" v-model="applicant.reasonable_adjustments">
-          <label class="custom-control-label" for="reasonable_adjustments_no">
+          <input
+            id="reasonable_adjustments_no"
+            v-model="applicant.reasonable_adjustments"
+            class="custom-control-input"
+            type="radio"
+            :value="false"
+          >
+          <label
+            class="custom-control-label"
+            for="reasonable_adjustments_no"
+          >
             No
           </label>
         </div>
 
-        <div class="form-group mt-3" v-if="applicant.reasonable_adjustments">
+        <div
+          v-if="applicant.reasonable_adjustments"
+          class="form-group mt-3"
+        >
           <label for="reasonable_adjustments_details">
             Provide details of your condition and request
           </label>
-          <textarea class="form-control" id="reasonable_adjustments_details" v-model="applicant.reasonable_adjustments_details" rows="3"></textarea>
+          <textarea
+            id="reasonable_adjustments_details"
+            v-model="applicant.reasonable_adjustments_details"
+            class="form-control"
+            rows="3"
+          />
           <div class="form-text">
             <p>We’ll contact you if we need to discuss your arrangements.</p>
             <p>If you would like to discuss reasonable adjustments in confidence with someone, please email <a href="mailto:dcj128@judicialappointments.gov.uk">dcj128@judicialappointments.gov.uk</a>.</p>
@@ -122,38 +213,41 @@
         </div>
       </fieldset>
 
-      <SaveAndContinueButtons :isSaving="isSaving" @saveAndContinue="saveAndContinue" />
+      <SaveAndContinueButtons
+        :is-saving="isSaving"
+        @saveAndContinue="saveAndContinue"
+      />
     </form>
   </section>
 </template>
 
 <script>
-  import DateInput from '@/components/DateInput';
-  import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
-  import BooleanInput from '@/components/BooleanInput';
+import DateInput from '@/components/DateInput';
+import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
+import BooleanInput from '@/components/BooleanInput';
 
-  export default {
-    components: {
-      BooleanInput,
-      SaveAndContinueButtons,
-      DateInput,
+export default {
+  components: {
+    BooleanInput,
+    SaveAndContinueButtons,
+    DateInput,
+  },
+  data() {
+    return {
+      applicant: this.$store.getters.applicant(),
+      isSaving: false,
+    };
+  },
+  methods: {
+    async saveAndContinue() {
+      await this.save();
+      this.$emit('continue');
     },
-    data() {
-      return {
-        applicant: this.$store.getters.applicant(),
-        isSaving: false,
-      };
+    async save() {
+      this.isSaving = true;
+      await this.$store.dispatch('saveApplicant', this.applicant);
+      this.isSaving = false;
     },
-    methods: {
-      async saveAndContinue() {
-        await this.save();
-        this.$emit('continue');
-      },
-      async save() {
-        this.isSaving = true;
-        await this.$store.dispatch('saveApplicant', this.applicant);
-        this.isSaving = false;
-      },
-    },
-  };
+  },
+};
 </script>

--- a/hosting/apply/src/views/Sections/Personal/Show.vue
+++ b/hosting/apply/src/views/Sections/Personal/Show.vue
@@ -1,68 +1,108 @@
 <template>
   <section class="card mb-3">
     <div class="card-header">
-      <h3 class="card-title">Personal Details</h3>
+      <h3 class="card-title">
+        Personal Details
+      </h3>
     </div>
     <div class="card-body">
       <table class="table">
         <tbody>
           <tr>
-            <th scope="row">Full Name</th>
+            <th scope="row">
+              Full Name
+            </th>
             <td>{{ applicant.full_name }}</td>
             <td>
-              <RouterLink to="/apply/personal">Change</RouterLink>
+              <RouterLink to="/apply/personal">
+                Change
+              </RouterLink>
             </td>
           </tr>
           <tr v-if="applicant.date_of_birth && applicant.date_of_birth.toLocaleDateString()">
-            <th scope="row">Date of Birth</th>
+            <th scope="row">
+              Date of Birth
+            </th>
             <td>{{ applicant.date_of_birth.toLocaleDateString() }}</td>
             <td>
-              <RouterLink to="/apply/personal">Change</RouterLink>
+              <RouterLink to="/apply/personal">
+                Change
+              </RouterLink>
             </td>
           </tr>
           <tr>
-            <th scope="row">National Insurance Number</th>
+            <th scope="row">
+              National Insurance Number
+            </th>
             <td>{{ applicant.national_insurance }}</td>
             <td>
-              <RouterLink to="/apply/personal">Change</RouterLink>
+              <RouterLink to="/apply/personal">
+                Change
+              </RouterLink>
             </td>
           </tr>
           <tr>
-            <th scope="row">Telephone Number</th>
+            <th scope="row">
+              Telephone Number
+            </th>
             <td>{{ applicant.phone }}</td>
             <td>
-              <RouterLink to="/apply/personal">Change</RouterLink>
+              <RouterLink to="/apply/personal">
+                Change
+              </RouterLink>
             </td>
           </tr>
           <tr>
-            <th scope="row">Your Address</th>
+            <th scope="row">
+              Your Address
+            </th>
             <td>
-              <p v-if="applicant.address_line_1">{{ applicant.address_line_1 }}</p>
-              <p v-if="applicant.address_line_2">{{ applicant.address_line_2 }}</p>
-              <p v-if="applicant.address_town">{{ applicant.address_town }}</p>
-              <p v-if="applicant.address_county">{{ applicant.address_county }}</p>
-              <p v-if="applicant.address_postcode">{{ applicant.address_postcode }}</p>
+              <p v-if="applicant.address_line_1">
+                {{ applicant.address_line_1 }}
+              </p>
+              <p v-if="applicant.address_line_2">
+                {{ applicant.address_line_2 }}
+              </p>
+              <p v-if="applicant.address_town">
+                {{ applicant.address_town }}
+              </p>
+              <p v-if="applicant.address_county">
+                {{ applicant.address_county }}
+              </p>
+              <p v-if="applicant.address_postcode">
+                {{ applicant.address_postcode }}
+              </p>
             </td>
             <td>
-              <RouterLink to="/apply/personal">Change</RouterLink>
+              <RouterLink to="/apply/personal">
+                Change
+              </RouterLink>
             </td>
           </tr>
           <tr>
-            <th scope="row">Reasonable Adjustments</th>
+            <th scope="row">
+              Reasonable Adjustments
+            </th>
             <td>
               {{ applicant.reasonable_adjustments ? "Yes" : "No" }}
             </td>
             <td>
-              <RouterLink to="/apply/personal">Change</RouterLink>
+              <RouterLink to="/apply/personal">
+                Change
+              </RouterLink>
             </td>
           </tr>
           <tr>
-            <th scope="row">Reasonable Adjustments Details</th>
+            <th scope="row">
+              Reasonable Adjustments Details
+            </th>
             <td>
               {{ applicant.reasonable_adjustments_details }}
             </td>
             <td>
-              <RouterLink to="/apply/personal">Change</RouterLink>
+              <RouterLink to="/apply/personal">
+                Change
+              </RouterLink>
             </td>
           </tr>
         </tbody>

--- a/hosting/apply/src/views/Sections/Preferences/Edit.vue
+++ b/hosting/apply/src/views/Sections/Preferences/Edit.vue
@@ -10,10 +10,18 @@
 
       <fieldset v-if="applicant.work_part_time">
         <legend>What sitting patterns are you interested in?</legend>
-        <SelectList id="sitting_patterns" :multiple="true" :options="selectListOptions.sitting_patterns" v-model="applicant.sitting_patterns" />
+        <SelectList
+          id="sitting_patterns"
+          v-model="applicant.sitting_patterns"
+          :multiple="true"
+          :options="selectListOptions.sitting_patterns"
+        />
       </fieldset>
 
-      <SaveAndContinueButtons :isSaving="isSaving" @saveAndContinue="saveAndContinue" />
+      <SaveAndContinueButtons
+        :is-saving="isSaving"
+        @saveAndContinue="saveAndContinue"
+      />
     </form>
   </section>
 </template>
@@ -35,9 +43,9 @@ export default {
       isSaving: false,
       selectListOptions: {
         sitting_patterns: [
-           '80%',
-           '90%',
-           'Blocks of at least 6 to 8 weeks'
+          '80%',
+          '90%',
+          'Blocks of at least 6 to 8 weeks',
         ],
       },
     };

--- a/hosting/apply/src/views/Sections/Preferences/Show.vue
+++ b/hosting/apply/src/views/Sections/Preferences/Show.vue
@@ -1,15 +1,17 @@
 <template>
   <section class="card mb-3">
     <div class="card-header">
-      <h3 class="card-title">Preferences</h3>
+      <h3 class="card-title">
+        Preferences
+      </h3>
     </div>
     <BooleanWithCheckboxes
       title="Are you interested in salaried part-time working?"
       subtitle="What sitting patterns are you interested in?"
-      changeLink="/apply/preferences"
-      :answeredYes="applicant.work_part_time"
+      change-link="/apply/preferences"
+      :answered-yes="applicant.work_part_time"
       :records="applicant.sitting_patterns"
-      />
+    />
   </section>
 </template>
 

--- a/hosting/apply/src/views/Sections/Qualifications/Edit.vue
+++ b/hosting/apply/src/views/Sections/Qualifications/Edit.vue
@@ -5,40 +5,67 @@
 
       <fieldset>
         <legend>What are your qualifications?</legend>
-        <RepeatableFields v-model="applicant.qualifications" :component="repeatableFields.Qualification" />
+        <RepeatableFields
+          v-model="applicant.qualifications"
+          :component="repeatableFields.Qualification"
+        />
       </fieldset>
 
       <fieldset>
         <legend>Are you qualified as a:</legend>
-        <SelectList :options="selectListOptions.qualifiedProfessions" :multiple="false" v-model="applicant.qualified_profession" id="qualified_profession" />
+        <SelectList
+          id="qualified_profession"
+          v-model="applicant.qualified_profession"
+          :options="selectListOptions.qualifiedProfessions"
+          :multiple="false"
+        />
       </fieldset>
 
       <fieldset>
         <legend>Where did you qualify?</legend>
-        <SelectList :options="selectListOptions.qualifiedLocations" v-model="applicant.location_qualified" id="location_qualified" />
+        <SelectList
+          id="location_qualified"
+          v-model="applicant.location_qualified"
+          :options="selectListOptions.qualifiedLocations"
+        />
       </fieldset>
 
       <div v-if="applicant.qualified_profession === 'Solicitor'">
         <fieldset>
           <legend>When were you entered on the Roll?</legend>
-          <div class="fieldset-text">For example, 02 2017</div>
-          <DateInput v-model="applicant.solicitor_date_on_roll" type="month" />
+          <div class="fieldset-text">
+            For example, 02 2017
+          </div>
+          <DateInput
+            v-model="applicant.solicitor_date_on_roll"
+            type="month"
+          />
         </fieldset>
       </div>
 
       <div v-if="applicant.qualified_profession === 'Advocate'">
         <fieldset>
           <legend>When were you called to the Faculty?</legend>
-          <div class="fieldset-text">For example, 02 2017</div>
-          <DateInput v-model="applicant.advocate_date_called_to_faculty" type="month" />
+          <div class="fieldset-text">
+            For example, 02 2017
+          </div>
+          <DateInput
+            v-model="applicant.advocate_date_called_to_faculty"
+            type="month"
+          />
         </fieldset>
       </div>
 
       <div v-if="applicant.qualified_profession === 'Barrister'">
         <fieldset>
           <legend>When were you called to the Bar?</legend>
-          <div class="fieldset-text">For example, 02 2017</div>
-          <DateInput v-model="applicant.barrister_date_called_to_bar" type="month" />
+          <div class="fieldset-text">
+            For example, 02 2017
+          </div>
+          <DateInput
+            v-model="applicant.barrister_date_called_to_bar"
+            type="month"
+          />
         </fieldset>
 
         <div v-if="applicant.location_qualified !== 'Northern Ireland'">
@@ -47,18 +74,38 @@
             <p>Have you completed pupillage?</p>
             <BooleanInput v-model="applicant.barrister_completed_pupillage" />
 
-            <div v-if="applicant.barrister_completed_pupillage" class="mt-3">
+            <div
+              v-if="applicant.barrister_completed_pupillage"
+              class="mt-3"
+            >
               <p>When did you complete pupillage?</p>
-              <div class="fieldset-text">For example, 02 2017</div>
-              <DateInput v-model="applicant.barrister_date_completed_pupillage" type="month" />
+              <div class="fieldset-text">
+                For example, 02 2017
+              </div>
+              <DateInput
+                v-model="applicant.barrister_date_completed_pupillage"
+                type="month"
+              />
             </div>
 
-            <div v-if="!applicant.barrister_completed_pupillage" class="mt-3">
+            <div
+              v-if="!applicant.barrister_completed_pupillage"
+              class="mt-3"
+            >
               <p>Why didn’t you complete pupillage?</p>
-              <textarea class="form-control" v-model="applicant.barrister_reason_pupillage_not_completed" rows="3"></textarea>
-              <p class="mt-3">Do you have an exemption certificate?</p>
+              <textarea
+                v-model="applicant.barrister_reason_pupillage_not_completed"
+                class="form-control"
+                rows="3"
+              />
+              <p class="mt-3">
+                Do you have an exemption certificate?
+              </p>
               <BooleanInput v-model="applicant.barrister_has_pupillage_exemption_certificate" />
-              <p v-if="applicant.barrister_has_pupillage_exemption_certificate" class="mt-3">
+              <p
+                v-if="applicant.barrister_has_pupillage_exemption_certificate"
+                class="mt-3"
+              >
                 Email your certificate to
                 <a href="mailto:dcj128@judicialappointments.gov.uk">dcj128@judicialappointments.gov.uk</a>
               </p>
@@ -67,58 +114,61 @@
         </div>
       </div>
 
-      <SaveAndContinueButtons :isSaving="isSaving" @saveAndContinue="saveAndContinue" />
+      <SaveAndContinueButtons
+        :is-saving="isSaving"
+        @saveAndContinue="saveAndContinue"
+      />
     </form>
   </section>
 </template>
 
 <script>
-  import DateInput from '@/components/DateInput';
-  import SelectList from '@/components/SelectList';
-  import BooleanInput from '@/components/BooleanInput';
-  import RepeatableFields from '@/components/RepeatableFields';
-  import Qualification from '@/views/RepeatableFields/Qualification';
-  import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
+import DateInput from '@/components/DateInput';
+import SelectList from '@/components/SelectList';
+import BooleanInput from '@/components/BooleanInput';
+import RepeatableFields from '@/components/RepeatableFields';
+import Qualification from '@/views/RepeatableFields/Qualification';
+import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
 
-  export default {
-    components: {
-      SaveAndContinueButtons,
-      DateInput,
-      SelectList,
-      BooleanInput,
-      RepeatableFields,
-    },
-    data() {
-      return {
-        applicant: this.$store.getters.applicant(),
-        isSaving: false,
-        selectListOptions: {
-          qualifiedProfessions: [
-            {value: 'Barrister', label: 'Barrister',},
-            {value: 'Solicitor', label: 'Solicitor',},
-            {value: 'Advocate', label: 'Advocate',}
-          ],
-          qualifiedLocations: [
-            'England and Wales',
-            'Scotland',
-            'Northern Ireland'
-          ],
-        },
-        repeatableFields: {
-          Qualification,
-        },
-      };
-    },
-    methods: {
-      async saveAndContinue() {
-        await this.save();
-        this.$emit('continue');
+export default {
+  components: {
+    SaveAndContinueButtons,
+    DateInput,
+    SelectList,
+    BooleanInput,
+    RepeatableFields,
+  },
+  data() {
+    return {
+      applicant: this.$store.getters.applicant(),
+      isSaving: false,
+      selectListOptions: {
+        qualifiedProfessions: [
+          {value: 'Barrister', label: 'Barrister'},
+          {value: 'Solicitor', label: 'Solicitor'},
+          {value: 'Advocate', label: 'Advocate'},
+        ],
+        qualifiedLocations: [
+          'England and Wales',
+          'Scotland',
+          'Northern Ireland',
+        ],
       },
-      async save() {
-        this.isSaving = true;
-        await this.$store.dispatch('saveApplicant', this.applicant);
-        this.isSaving = false;
+      repeatableFields: {
+        Qualification,
       },
+    };
+  },
+  methods: {
+    async saveAndContinue() {
+      await this.save();
+      this.$emit('continue');
     },
-  };
+    async save() {
+      this.isSaving = true;
+      await this.$store.dispatch('saveApplicant', this.applicant);
+      this.isSaving = false;
+    },
+  },
+};
 </script>

--- a/hosting/apply/src/views/Sections/Qualifications/Show.vue
+++ b/hosting/apply/src/views/Sections/Qualifications/Show.vue
@@ -1,126 +1,178 @@
 <template>
   <section class="card mb-3">
     <div class="card-header">
-      <h3 class="card-title">Qualifications</h3>
+      <h3 class="card-title">
+        Qualifications
+      </h3>
     </div>
 
     <div class="card-body">
-
       <h4>Qualifications</h4>
-      <table class="table" v-for="qualification in applicant.qualifications" :key="qualification.qualification">
+      <table
+        v-for="qualification in applicant.qualifications"
+        :key="qualification.qualification"
+        class="table"
+      >
         <tbody>
           <tr>
-            <th scope="row">Qualification</th>
-            <td>{{qualification.qualification}}</td>
+            <th scope="row">
+              Qualification
+            </th>
+            <td>{{ qualification.qualification }}</td>
           </tr>
           <tr>
-            <th scope="row">College or university</th>
-            <td>{{qualification.college}}</td>
+            <th scope="row">
+              College or university
+            </th>
+            <td>{{ qualification.college }}</td>
           </tr>
           <tr>
-            <th scope="row">Qualification date</th>
+            <th scope="row">
+              Qualification date
+            </th>
             <td>{{ qualification.date.toLocaleDateString() }}</td>
           </tr>
           <tr>
             <td colspan="2">
-              <RouterLink to="/apply/qualifications" class="float-right">Change</RouterLink>
+              <RouterLink
+                to="/apply/qualifications"
+                class="float-right"
+              >
+                Change
+              </RouterLink>
             </td>
           </tr>
         </tbody>
       </table>
 
-    <table class="table">
-      <tbody>
-        <tr>
-          <th scope="row">Qualified profession</th>
-          <td>{{ applicant.qualified_profession }}</td>
-          <td>
-            <RouterLink to="/apply/qualifications">Change</RouterLink>
-          </td>
-        </tr>
-        <tr>
-          <th scope="row">Where did you qualify?</th>
-          <td>{{ applicant.location_qualified }}</td>
-          <td>
-            <RouterLink to="/apply/qualifications">Change</RouterLink>
-          </td>
-        </tr>
+      <table class="table">
+        <tbody>
+          <tr>
+            <th scope="row">
+              Qualified profession
+            </th>
+            <td>{{ applicant.qualified_profession }}</td>
+            <td>
+              <RouterLink to="/apply/qualifications">
+                Change
+              </RouterLink>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">
+              Where did you qualify?
+            </th>
+            <td>{{ applicant.location_qualified }}</td>
+            <td>
+              <RouterLink to="/apply/qualifications">
+                Change
+              </RouterLink>
+            </td>
+          </tr>
 
-        <tr v-if="applicant.qualified_profession === 'Solicitor'">
-          <th scope="row">When were you entered on the Roll?</th>
-          <td v-if="applicant.solicitor_date_on_roll">
-            {{ applicant.solicitor_date_on_roll.toLocaleDateString() }}
-          </td>
-          <td v-else></td>
-          <td>
-            <RouterLink to="/apply/qualifications">Change</RouterLink>
-          </td>
-        </tr>
+          <tr v-if="applicant.qualified_profession === 'Solicitor'">
+            <th scope="row">
+              When were you entered on the Roll?
+            </th>
+            <td v-if="applicant.solicitor_date_on_roll">
+              {{ applicant.solicitor_date_on_roll.toLocaleDateString() }}
+            </td>
+            <td v-else />
+            <td>
+              <RouterLink to="/apply/qualifications">
+                Change
+              </RouterLink>
+            </td>
+          </tr>
 
-        <tr v-if="applicant.qualified_profession === 'Advocate'">
-          <th scope="row">When were you called to the Faculty?</th>
-          <td v-if="applicant.advocate_date_called_to_faculty">
-            {{ applicant.advocate_date_called_to_faculty.toLocaleDateString() }}
-          </td>
-          <td v-else></td>
-          <td>
-            <RouterLink to="/apply/qualifications">Change</RouterLink>
-          </td>
-        </tr>
+          <tr v-if="applicant.qualified_profession === 'Advocate'">
+            <th scope="row">
+              When were you called to the Faculty?
+            </th>
+            <td v-if="applicant.advocate_date_called_to_faculty">
+              {{ applicant.advocate_date_called_to_faculty.toLocaleDateString() }}
+            </td>
+            <td v-else />
+            <td>
+              <RouterLink to="/apply/qualifications">
+                Change
+              </RouterLink>
+            </td>
+          </tr>
 
-        <tr v-if="applicant.qualified_profession === 'Barrister'">
-          <th scope="row">When were you called to the Bar?</th>
-          <td v-if="applicant.barrister_date_called_to_bar">
-            {{ applicant.barrister_date_called_to_bar.toLocaleDateString() }}
-          </td>
-          <td v-else></td>
-          <td>
-            <RouterLink to="/apply/qualifications">Change</RouterLink>
-          </td>
-        </tr>
+          <tr v-if="applicant.qualified_profession === 'Barrister'">
+            <th scope="row">
+              When were you called to the Bar?
+            </th>
+            <td v-if="applicant.barrister_date_called_to_bar">
+              {{ applicant.barrister_date_called_to_bar.toLocaleDateString() }}
+            </td>
+            <td v-else />
+            <td>
+              <RouterLink to="/apply/qualifications">
+                Change
+              </RouterLink>
+            </td>
+          </tr>
 
-        <tr v-if="applicant.qualified_profession === 'Barrister' && applicant.location_qualified !== 'Northern Ireland'">
-          <th scope="row">Have you completed pupillage?</th>
-          <td>{{ applicant.barrister_completed_pupillage ? "Yes" : "No" }}</td>
-          <td>
-            <RouterLink to="/apply/qualifications">Change</RouterLink>
-          </td>
-        </tr>
+          <tr v-if="applicant.qualified_profession === 'Barrister' && applicant.location_qualified !== 'Northern Ireland'">
+            <th scope="row">
+              Have you completed pupillage?
+            </th>
+            <td>{{ applicant.barrister_completed_pupillage ? "Yes" : "No" }}</td>
+            <td>
+              <RouterLink to="/apply/qualifications">
+                Change
+              </RouterLink>
+            </td>
+          </tr>
 
-        <tr v-if="applicant.qualified_profession === 'Barrister' && applicant.location_qualified !== 'Northern Ireland' && applicant.barrister_completed_pupillage">
-          <th scope="row">When did you complete pupillage?</th>
-          <td>
-            {{ applicant.barrister_date_completed_pupillage.toLocaleDateString() }}
-          </td>
-          <td>
-            <RouterLink to="/apply/qualifications">Change</RouterLink>
-          </td>
-        </tr>
+          <tr v-if="applicant.qualified_profession === 'Barrister' && applicant.location_qualified !== 'Northern Ireland' && applicant.barrister_completed_pupillage">
+            <th scope="row">
+              When did you complete pupillage?
+            </th>
+            <td>
+              {{ applicant.barrister_date_completed_pupillage.toLocaleDateString() }}
+            </td>
+            <td>
+              <RouterLink to="/apply/qualifications">
+                Change
+              </RouterLink>
+            </td>
+          </tr>
 
-        <tr v-if="applicant.qualified_profession === 'Barrister' && applicant.location_qualified !== 'Northern Ireland' && !applicant.barrister_completed_pupillage">
-          <th scope="row">Why didn’t you complete pupillage?</th>
-          <td>{{ applicant.barrister_reason_pupillage_not_completed }}</td>
-          <td>
-            <RouterLink to="/apply/qualifications">Change</RouterLink>
-          </td>
-        </tr>
+          <tr v-if="applicant.qualified_profession === 'Barrister' && applicant.location_qualified !== 'Northern Ireland' && !applicant.barrister_completed_pupillage">
+            <th scope="row">
+              Why didn’t you complete pupillage?
+            </th>
+            <td>{{ applicant.barrister_reason_pupillage_not_completed }}</td>
+            <td>
+              <RouterLink to="/apply/qualifications">
+                Change
+              </RouterLink>
+            </td>
+          </tr>
 
-        <tr v-if="applicant.qualified_profession === 'Barrister' && applicant.location_qualified !== 'Northern Ireland' && !applicant.barrister_completed_pupillage">
-          <th scope="row">Do you have an exemption certificate?</th>
-          <td>
-            <p>{{ applicant.barrister_has_pupillage_exemption_certificate ? "Yes" : "No" }}</p>
-            <p v-if="applicant.barrister_has_pupillage_exemption_certificate">
-              Email your certificate to
-              <a href="mailto:dcj128@judicialappointments.gov.uk">dcj128@judicialappointments.gov.uk</a>
-            </p>
-          </td>
-          <td>
-            <RouterLink to="/apply/qualifications">Change</RouterLink>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+          <tr v-if="applicant.qualified_profession === 'Barrister' && applicant.location_qualified !== 'Northern Ireland' && !applicant.barrister_completed_pupillage">
+            <th scope="row">
+              Do you have an exemption certificate?
+            </th>
+            <td>
+              <p>{{ applicant.barrister_has_pupillage_exemption_certificate ? "Yes" : "No" }}</p>
+              <p v-if="applicant.barrister_has_pupillage_exemption_certificate">
+                Email your certificate to
+                <a href="mailto:dcj128@judicialappointments.gov.uk">dcj128@judicialappointments.gov.uk</a>
+              </p>
+            </td>
+            <td>
+              <RouterLink to="/apply/qualifications">
+                Change
+              </RouterLink>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </section>
 </template>
 

--- a/hosting/apply/src/views/Sections/Review/Edit.vue
+++ b/hosting/apply/src/views/Sections/Review/Edit.vue
@@ -12,11 +12,20 @@
     <Declarations />
     <Diversity />
     <Outreach />
-    <div class="form-actions" v-if="application.state != 'submitted'">
-      <button class="btn btn-primary mr-2" @click.prevent="saveAndSubmit">
+    <div
+      v-if="application.state != 'submitted'"
+      class="form-actions"
+    >
+      <button
+        class="btn btn-primary mr-2"
+        @click.prevent="saveAndSubmit"
+      >
         Submit application
       </button>
-      <span class="spinner-border spinner-border-sm text-secondary" v-if="isSaving"></span>
+      <span
+        v-if="isSaving"
+        class="spinner-border spinner-border-sm text-secondary"
+      />
     </div>
   </section>
 </template>

--- a/hosting/apply/src/views/Sections/SelfAssessment/Edit.vue
+++ b/hosting/apply/src/views/Sections/SelfAssessment/Edit.vue
@@ -3,7 +3,10 @@
     <form @submit.prevent="save">
       <h2>Your self assessment</h2>
 
-      <div class="card mb-3" v-if="application.state === 'submitted'">
+      <div
+        v-if="application.state === 'submitted'"
+        class="card mb-3"
+      >
         <div class="card-header">
           <h2 class="card-title">
             You have submitted your application for this vacancy
@@ -18,34 +21,69 @@
       <fieldset :disabled="application.state === 'submitted'">
         <legend>Self Assessment</legend>
         <div class="fieldset-text">
-          <p>Please refer to the
-          <a href="https://www.judicialappointments.gov.uk/sites/default/files/sync/128_final_competency_framework.pdf" target="_blank">guidance and competency framework</a>
-            on the JAC website before completing this part of your application.</p>
+          <p>
+            Please refer to the
+            <a
+              href="https://www.judicialappointments.gov.uk/sites/default/files/sync/128_final_competency_framework.pdf"
+              target="_blank"
+            >guidance and competency framework</a>
+            on the JAC website before completing this part of your application.
+          </p>
           <p>You have a maximum of 250 words for each competency.</p>
         </div>
         <div class="form-group">
           <label for="leadership">Leadership</label>
-          <textarea class="form-control" id="leadership" rows="9" v-model="application.competency_leadership"></textarea>
+          <textarea
+            id="leadership"
+            v-model="application.competency_leadership"
+            class="form-control"
+            rows="9"
+          />
         </div>
         <div class="form-group">
           <label for="exercising_judgement">Exercising Judgement</label>
-          <textarea class="form-control" id="exercising_judgement" rows="9" v-model="application.competency_exercising_judgement"></textarea>
+          <textarea
+            id="exercising_judgement"
+            v-model="application.competency_exercising_judgement"
+            class="form-control"
+            rows="9"
+          />
         </div>
         <div class="form-group">
           <label for="possessing_and_building_knowledge">Possessing and Building Knowledge</label>
-          <textarea class="form-control" id="possessing_and_building_knowledge" rows="9" v-model="application.competency_possessing_and_building_knowledge"></textarea>
+          <textarea
+            id="possessing_and_building_knowledge"
+            v-model="application.competency_possessing_and_building_knowledge"
+            class="form-control"
+            rows="9"
+          />
         </div>
         <div class="form-group">
           <label for="assimilating_and_clarifying_information">Assimilating and Clarifying Information</label>
-          <textarea class="form-control" id="assimilating_and_clarifying_information" rows="9" v-model="application.competency_assimilating_and_clarifying_information"></textarea>
+          <textarea
+            id="assimilating_and_clarifying_information"
+            v-model="application.competency_assimilating_and_clarifying_information"
+            class="form-control"
+            rows="9"
+          />
         </div>
         <div class="form-group">
           <label for="working_and_communicating_with_others">Working and Communicating with Others</label>
-          <textarea class="form-control" id="working_and_communicating_with_others" rows="9" v-model="application.competency_working_and_communicating_with_others"></textarea>
+          <textarea
+            id="working_and_communicating_with_others"
+            v-model="application.competency_working_and_communicating_with_others"
+            class="form-control"
+            rows="9"
+          />
         </div>
         <div class="form-group">
           <label for="managing_work_effectively">Managing Work Effectively</label>
-          <textarea class="form-control" id="managing_work_effectively" rows="9" v-model="application.competency_managing_work_effectively"></textarea>
+          <textarea
+            id="managing_work_effectively"
+            v-model="application.competency_managing_work_effectively"
+            class="form-control"
+            rows="9"
+          />
         </div>
       </fieldset>
 
@@ -53,13 +91,20 @@
         <legend>Additional Selection Criterion</legend>
         <div class="fieldset-text">
           Refer to the
-          <a href="https://www.judicialappointments.gov.uk/128-senior-circuit-judge-designated-civil-judge-information-page#additional-selection-criterion"
-             target="_blank">‘Additional Selection Criterion’</a>
+          <a
+            href="https://www.judicialappointments.gov.uk/128-senior-circuit-judge-designated-civil-judge-information-page#additional-selection-criterion"
+            target="_blank"
+          >‘Additional Selection Criterion’</a>
           section of the vacancy information page for more information about this requirement.
         </div>
         <div class="form-group">
           <label for="additional_selection_criteria">Provide details of how you meet this requirement</label>
-          <textarea class="form-control" id="additional_selection_criteria" rows="3" v-model="application.additional_selection_criteria"></textarea>
+          <textarea
+            id="additional_selection_criteria"
+            v-model="application.additional_selection_criteria"
+            class="form-control"
+            rows="3"
+          />
         </div>
       </fieldset>
 
@@ -67,17 +112,27 @@
         <legend>Reasonable Length of Service</legend>
         <div class="fieldset-text">
           Refer to the
-          <a href="https://www.judicialappointments.gov.uk/128-senior-circuit-judge-designated-civil-judge-information-page#reasonable-length-of-service"
-             target="_blank">‘Reasonable Length of Service’</a>
+          <a
+            href="https://www.judicialappointments.gov.uk/128-senior-circuit-judge-designated-civil-judge-information-page#reasonable-length-of-service"
+            target="_blank"
+          >‘Reasonable Length of Service’</a>
           section of the vacancy information page for more information about this requirement.
         </div>
         <div class="form-group">
           <label>Are you able to provide 3 years’ service?</label>
           <BooleanInput v-model="application.length_of_service_accepted" />
         </div>
-        <div class="form-group" v-if="application.length_of_service_accepted === false">
+        <div
+          v-if="application.length_of_service_accepted === false"
+          class="form-group"
+        >
           <label for="length_of_service_mitigation">Provide any mitigation you’d like considered</label>
-          <textarea class="form-control" id="length_of_service_mitigation" rows="3" v-model="application.length_of_service_mitigation"></textarea>
+          <textarea
+            id="length_of_service_mitigation"
+            v-model="application.length_of_service_mitigation"
+            class="form-control"
+            rows="3"
+          />
         </div>
       </fieldset>
 
@@ -87,7 +142,11 @@
         <BooleanInput v-model="application.has_section_9_1_authorisation" />
       </fieldset>
 
-      <SaveAndContinueButtons v-if="application.state !== 'submitted'" :isSaving="isSaving" @saveAndContinue="saveAndContinue" />
+      <SaveAndContinueButtons
+        v-if="application.state !== 'submitted'"
+        :is-saving="isSaving"
+        @saveAndContinue="saveAndContinue"
+      />
     </form>
   </section>
 </template>

--- a/hosting/apply/src/views/Sections/SelfAssessment/Show.vue
+++ b/hosting/apply/src/views/Sections/SelfAssessment/Show.vue
@@ -1,7 +1,9 @@
 <template>
   <section class="card mb-3">
     <div class="card-header">
-      <h3 class="card-title">Your Self Assessment</h3>
+      <h3 class="card-title">
+        Your Self Assessment
+      </h3>
     </div>
 
     <div class="card-body">
@@ -9,45 +11,69 @@
       <table class="table long-answers">
         <tbody>
           <tr>
-            <th scope="row">Leadership</th>
+            <th scope="row">
+              Leadership
+            </th>
             <td>{{ application.competency_leadership }}</td>
             <td>
-              <RouterLink to="/apply/self-assessment">Change</RouterLink>
+              <RouterLink to="/apply/self-assessment">
+                Change
+              </RouterLink>
             </td>
           </tr>
           <tr>
-            <th scope="row">Exercising Judgement</th>
+            <th scope="row">
+              Exercising Judgement
+            </th>
             <td>{{ application.competency_exercising_judgement }}</td>
             <td>
-              <RouterLink to="/apply/self-assessment">Change</RouterLink>
+              <RouterLink to="/apply/self-assessment">
+                Change
+              </RouterLink>
             </td>
           </tr>
           <tr>
-            <th scope="row">Possessing and Building Knowledge</th>
+            <th scope="row">
+              Possessing and Building Knowledge
+            </th>
             <td>{{ application.competency_possessing_and_building_knowledge }}</td>
             <td>
-              <RouterLink to="/apply/self-assessment">Change</RouterLink>
+              <RouterLink to="/apply/self-assessment">
+                Change
+              </RouterLink>
             </td>
           </tr>
           <tr>
-            <th scope="row">Assimilating and Clarifying Information</th>
+            <th scope="row">
+              Assimilating and Clarifying Information
+            </th>
             <td>{{ application.competency_assimilating_and_clarifying_information }}</td>
             <td>
-              <RouterLink to="/apply/self-assessment">Change</RouterLink>
+              <RouterLink to="/apply/self-assessment">
+                Change
+              </RouterLink>
             </td>
           </tr>
           <tr>
-            <th scope="row">Working and Communicating with Others</th>
+            <th scope="row">
+              Working and Communicating with Others
+            </th>
             <td>{{ application.competency_working_and_communicating_with_others }}</td>
             <td>
-              <RouterLink to="/apply/self-assessment">Change</RouterLink>
+              <RouterLink to="/apply/self-assessment">
+                Change
+              </RouterLink>
             </td>
           </tr>
           <tr>
-            <th scope="row">Managing Work Effectively</th>
+            <th scope="row">
+              Managing Work Effectively
+            </th>
             <td>{{ application.competency_managing_work_effectively }}</td>
             <td>
-              <RouterLink to="/apply/self-assessment">Change</RouterLink>
+              <RouterLink to="/apply/self-assessment">
+                Change
+              </RouterLink>
             </td>
           </tr>
         </tbody>
@@ -57,10 +83,14 @@
       <table class="table long-answers">
         <tbody>
           <tr>
-            <th scope="row">Provide details of how you meet this requirement</th>
-            <td>{{ application.additional_selection_criteria}}</td>
+            <th scope="row">
+              Provide details of how you meet this requirement
+            </th>
+            <td>{{ application.additional_selection_criteria }}</td>
             <td>
-              <RouterLink to="/apply/self-assessment">Change</RouterLink>
+              <RouterLink to="/apply/self-assessment">
+                Change
+              </RouterLink>
             </td>
           </tr>
         </tbody>
@@ -70,17 +100,25 @@
       <table class="table">
         <tbody>
           <tr>
-            <th scope="row">Are you able to provide 3 years’ service?</th>
+            <th scope="row">
+              Are you able to provide 3 years’ service?
+            </th>
             <td>{{ application.length_of_service_accepted ? 'Yes' : 'No' }}</td>
             <td>
-              <RouterLink to="/apply/self-assessment">Change</RouterLink>
+              <RouterLink to="/apply/self-assessment">
+                Change
+              </RouterLink>
             </td>
           </tr>
           <tr v-if="application.length_of_service_accepted === false">
-            <th scope="row">Provide any mitigation you’d like considered</th>
+            <th scope="row">
+              Provide any mitigation you’d like considered
+            </th>
             <td>{{ application.length_of_service_mitigation }}</td>
             <td>
-              <RouterLink to="/apply/self-assessment">Change</RouterLink>
+              <RouterLink to="/apply/self-assessment">
+                Change
+              </RouterLink>
             </td>
           </tr>
         </tbody>
@@ -90,10 +128,14 @@
       <table class="table">
         <tbody>
           <tr>
-            <th scope="row">Do you currently have a Section 9(1) authorisation?</th>
+            <th scope="row">
+              Do you currently have a Section 9(1) authorisation?
+            </th>
             <td>{{ application.has_section_9_1_authorisation ? "Yes" : "No" }}</td>
             <td>
-              <RouterLink to="/apply/self-assessment">Change</RouterLink>
+              <RouterLink to="/apply/self-assessment">
+                Change
+              </RouterLink>
             </td>
           </tr>
         </tbody>
@@ -103,13 +145,13 @@
 </template>
 
 <script>
-  export default {
-    data() {
-      return {
-        application: this.$store.getters.application(),
-      };
-    },
-  };
+export default {
+  data() {
+    return {
+      application: this.$store.getters.application(),
+    };
+  },
+};
 </script>
 
 <style scoped>

--- a/hosting/apply/src/views/Sections/Submitted/Show.vue
+++ b/hosting/apply/src/views/Sections/Submitted/Show.vue
@@ -1,16 +1,22 @@
 <template>
   <section>
-    <article class="card" v-if="application.state === 'submitted'">
+    <article
+      v-if="application.state === 'submitted'"
+      class="card"
+    >
       <div class="card-header">
         <h2 class="card-title">
           Thank you for your application
         </h2>
       </div>
       <div class="card-body">
-        You have applied for <strong>{{vacancy.jac_ref}}: {{vacancy.title}}</strong>
+        You have applied for <strong>{{ vacancy.jac_ref }}: {{ vacancy.title }}</strong>
       </div>
     </article>
-    <article class="card" v-else>
+    <article
+      v-else
+      class="card"
+    >
       <div class="card-header">
         <h2 class="card-title">
           Please submit your application
@@ -18,11 +24,13 @@
       </div>
       <div class="card-body">
         <p>
-          You are applying for <strong>{{vacancy.jac_ref}}: {{vacancy.title}}</strong>
+          You are applying for <strong>{{ vacancy.jac_ref }}: {{ vacancy.title }}</strong>
         </p>
         <p>
           Your application is not complete until you have reviewed and submitted. Please do so on
-          the <router-link :to="'Review'">Review and Submit</router-link> page.
+          the <router-link :to="'Review'">
+            Review and Submit
+          </router-link> page.
         </p>
       </div>
     </article>

--- a/hosting/apply/src/views/SignIn.vue
+++ b/hosting/apply/src/views/SignIn.vue
@@ -3,7 +3,12 @@
     <Banner class="text-center" />
     <div class="login-container">
       <div class="text-center mb-3 mt-5">
-        <img src="@/assets/jac-logo.svg" alt="Judicial Appointments Commission" width="197" height="66">
+        <img
+          src="@/assets/jac-logo.svg"
+          alt="Judicial Appointments Commission"
+          width="197"
+          height="66"
+        >
       </div>
       <p>
         To apply for this role, create an account with your email address and choose a password.
@@ -17,21 +22,21 @@
 </template>
 
 <script>
-  import FirebaseUI from '@/components/FirebaseUI';
-  import Banner from '@/components/Banner';
+import FirebaseUI from '@/components/FirebaseUI';
+import Banner from '@/components/Banner';
 
-  export default {
-    components: {
-      FirebaseUI,
-      Banner,
+export default {
+  components: {
+    FirebaseUI,
+    Banner,
+  },
+  methods: {
+    loginRedirect(authResult) {
+      this.$store.dispatch('setCurrentUser', authResult.user);
+      this.$router.push('/');
     },
-    methods: {
-      loginRedirect(authResult) {
-        this.$store.dispatch('setCurrentUser', authResult.user);
-        this.$router.push('/');
-      },
-    },
-  };
+  },
+};
 </script>
 
 <style scoped>

--- a/hosting/apply/src/views/VerifyEmail.vue
+++ b/hosting/apply/src/views/VerifyEmail.vue
@@ -2,7 +2,7 @@
   <main class="container">
     <h1>Verify your email address</h1>
     <p>The JAC needs to make sure we have the right email address for you.</p>
-    <p>We've sent an email to <strong>{{email}}</strong> containing a link to verify your email address.</p>
+    <p>We've sent an email to <strong>{{ email }}</strong> containing a link to verify your email address.</p>
     <p>Follow the link to complete your registration and start your application.</p>
 
     <section class="mt-5">
@@ -10,10 +10,18 @@
       <p>It could take up to 10 minutes for the email to arrive.</p>
       <p>Don't forget to check your 'spam' or 'junk mail' folder in case it didn't go into your inbox.</p>
       <p>If it still hasn't arrived after 10 minutes, you can resend the email:</p>
-      <button class="btn btn-primary" type="button" :disabled="sendInProgress" @click.prevent="sendVerificationEmail">
+      <button
+        class="btn btn-primary"
+        type="button"
+        :disabled="sendInProgress"
+        @click.prevent="sendVerificationEmail"
+      >
         Resend email
       </button>
-      <span class="spinner-border spinner-border-sm text-secondary ml-2" v-if="sendInProgress"></span>
+      <span
+        v-if="sendInProgress"
+        class="spinner-border spinner-border-sm text-secondary ml-2"
+      />
     </section>
   </main>
 </template>
@@ -21,23 +29,23 @@
 <script>
 import {functions} from '@/firebase';
 
-  export default {
-    data() {
-      return {
-        email: this.$store.getters.currentUserEmail,
-        sendInProgress: false,
-      };
+export default {
+  data() {
+    return {
+      email: this.$store.getters.currentUserEmail,
+      sendInProgress: false,
+    };
+  },
+  methods: {
+    sendVerificationEmail() {
+      const send = functions().httpsCallable('sendVerificationEmail');
+      this.sendInProgress = true;
+      send().finally(() => {
+        this.sendInProgress = false;
+      });
     },
-    methods: {
-      sendVerificationEmail() {
-        const send = functions().httpsCallable('sendVerificationEmail');
-        this.sendInProgress = true;
-        send().finally(() => {
-          this.sendInProgress = false;
-        });
-      },
-    },
-  };
+  },
+};
 </script>
 
 <style scoped>

--- a/hosting/apply/tests/unit/components/DateInput.spec.js
+++ b/hosting/apply/tests/unit/components/DateInput.spec.js
@@ -4,7 +4,7 @@ import DateInput from '@/components/DateInput';
 describe('components/DateInput', () => {
   const createTestSubject = (value) => {
     return shallowMount(DateInput, {
-      propsData: {value,},
+      propsData: {value},
     });
   };
 
@@ -20,7 +20,7 @@ describe('components/DateInput', () => {
         const goodValues = [
           ['a Date object', new Date()],
           ['a null value', null],
-          ['an undefined value', undefined]
+          ['an undefined value', undefined],
         ];
 
         it.each(goodValues)('accepts %s', (label, value) => {
@@ -33,7 +33,7 @@ describe('components/DateInput', () => {
           ['a String', '2019-01-01'],
           ['a Number', 1550583417768],
           ['boolean true', true],
-          ['boolean false', true]
+          ['boolean false', true],
         ];
 
         it.each(badValues)('does not accept %s', (label, value) => {
@@ -56,7 +56,7 @@ describe('components/DateInput', () => {
       describe('valid values', () => {
         const goodValues = [
           ['date'],
-          ['month']
+          ['month'],
         ];
 
         it.each(goodValues)('accepts "%s"', (value) => {
@@ -69,7 +69,7 @@ describe('components/DateInput', () => {
           ['ymd'],
           ['ym'],
           ['a bad string'],
-          [true]
+          [true],
         ];
 
         it.each(badValues)('does not accept "%s"', (value) => {
@@ -89,14 +89,14 @@ describe('components/DateInput', () => {
       describe('getter', () => {
         describe('given `day` is null', () => {
           it('returns null', () => {
-            subject.setData({ day: null, });
+            subject.setData({ day: null });
             expect(subject.vm.dayInput).toBe(null);
           });
         });
 
         describe('given `day` is a number', () => {
           it('returns `day` as a string', () => {
-            subject.setData({ day: 15, });
+            subject.setData({ day: 15 });
             const value = subject.vm.dayInput;
 
             expect(typeof value).toBe('string');
@@ -105,7 +105,7 @@ describe('components/DateInput', () => {
           });
 
           it('zero pads single digit values to 2 characters', () => {
-            subject.setData({ day: 1, });
+            subject.setData({ day: 1 });
             const value = subject.vm.dayInput;
 
             expect(typeof value).toBe('string');
@@ -154,14 +154,14 @@ describe('components/DateInput', () => {
       describe('getter', () => {
         describe('given `month` is null', () => {
           it('returns null', () => {
-            subject.setData({ month: null, });
+            subject.setData({ month: null });
             expect(subject.vm.monthInput).toBe(null);
           });
         });
 
         describe('given `month` is a number', () => {
           it('returns `month` as a string', () => {
-            subject.setData({ month: 10, });
+            subject.setData({ month: 10 });
             const value = subject.vm.monthInput;
 
             expect(typeof value).toBe('string');
@@ -170,7 +170,7 @@ describe('components/DateInput', () => {
           });
 
           it('zero pads single digit values to 2 characters', () => {
-            subject.setData({ month: 1, });
+            subject.setData({ month: 1 });
             const value = subject.vm.monthInput;
 
             expect(typeof value).toBe('string');
@@ -219,14 +219,14 @@ describe('components/DateInput', () => {
       describe('getter', () => {
         describe('given `year` is null', () => {
           it('returns null', () => {
-            subject.setData({ year: null, });
+            subject.setData({ year: null });
             expect(subject.vm.yearInput).toBe(null);
           });
         });
 
         describe('given `year` is a number', () => {
           it('returns `year` as a number', () => {
-            subject.setData({ year: 1986, });
+            subject.setData({ year: 1986 });
             const value = subject.vm.yearInput;
 
             expect(typeof value).toBe('number');
@@ -255,21 +255,21 @@ describe('components/DateInput', () => {
     describe('dateConstructor', () => {
       describe('given property type="date"', () => {
         beforeEach(() => {
-          subject.setProps({type: 'date',});
+          subject.setProps({type: 'date'});
         });
 
         describe('and `day`, `month` and `year` fields are set', () => {
           it('returns an array of Date constructor arguments', () => {
-            subject.setData({day: 12, month: 4, year: 1980,});
+            subject.setData({day: 12, month: 4, year: 1980});
             expect(subject.vm.dateConstructor).toHaveLength(3);
             expect(subject.vm.dateConstructor).toEqual([1980, 3, 12]);
           });
 
           it('adjusts month to be zero-indexed, as required by Date constructor', () => {
-            subject.setData({day: 1, month: 1, year: 1960,});
+            subject.setData({day: 1, month: 1, year: 1960});
             expect(subject.vm.dateConstructor).toEqual([1960, 0, 1]);
 
-            subject.setData({day: 25, month: 12, year: 1960,});
+            subject.setData({day: 25, month: 12, year: 1960});
             expect(subject.vm.dateConstructor).toEqual([1960, 11, 25]);
           });
         });
@@ -277,21 +277,21 @@ describe('components/DateInput', () => {
 
       describe('given property type="month"', () => {
         beforeEach(() => {
-          subject.setProps({type: 'month',});
+          subject.setProps({type: 'month'});
         });
 
         describe('and `month` and `year` fields are set', () => {
           it('returns an array of Date constructor arguments', () => {
-            subject.setData({day: 12, month: 4, year: 1980,});
+            subject.setData({day: 12, month: 4, year: 1980});
             expect(subject.vm.dateConstructor).toHaveLength(2);
             expect(subject.vm.dateConstructor).toEqual([1980, 3]);
           });
 
           it('adjusts month to be zero-indexed, as required by Date constructor', () => {
-            subject.setData({day: 1, month: 1, year: 1960,});
+            subject.setData({day: 1, month: 1, year: 1960});
             expect(subject.vm.dateConstructor).toEqual([1960, 0]);
 
-            subject.setData({day: 25, month: 12, year: 1960,});
+            subject.setData({day: 25, month: 12, year: 1960});
             expect(subject.vm.dateConstructor).toEqual([1960, 11]);
           });
         });
@@ -299,13 +299,13 @@ describe('components/DateInput', () => {
 
       describe('given at least one field is null', () => {
         const nullValueCombinations = [
-          ['`day` is null',                      {day: null, month: 4,    year: 1980,}],
-          ['`month` is null',                    {day: 12,   month: null, year: 1980,}],
-          ['`year` is null',                     {day: 12,   month: 4,    year: null,}],
-          ['`day` and `month` are null',         {day: null, month: null, year: 1980,}],
-          ['`day` and `year` are null',          {day: null, month: 4,    year: null,}],
-          ['`month` and `year` are null',        {day: 12,   month: null, year: null,}],
-          ['`day`, `month` and `year` are null', {day: null, month: null, year: null,}]
+          ['`day` is null',                      {day: null, month: 4,    year: 1980}],
+          ['`month` is null',                    {day: 12,   month: null, year: 1980}],
+          ['`year` is null',                     {day: 12,   month: 4,    year: null}],
+          ['`day` and `month` are null',         {day: null, month: null, year: 1980}],
+          ['`day` and `year` are null',          {day: null, month: 4,    year: null}],
+          ['`month` and `year` are null',        {day: 12,   month: null, year: null}],
+          ['`day`, `month` and `year` are null', {day: null, month: null, year: null}],
         ];
 
         it.each(nullValueCombinations)('returns null (%s)', (label, data) => {
@@ -319,7 +319,7 @@ describe('components/DateInput', () => {
       describe('getter', () => {
         describe('given the date is not set (`dateConstructor` returns null)', () => {
           it('returns null', () => {
-            subject.setData({day: null, month: null, year: null,});
+            subject.setData({day: null, month: null, year: null});
             expect(subject.vm.date).toBe(null);
           });
         });
@@ -331,7 +331,7 @@ describe('components/DateInput', () => {
 
           it('is created as a UTC Date (not in local timezone)', () => {
             // Choosing a date where London is in BST so we can test local time vs UTC
-            subject.setData({day: 1, month: 6, year: 2018,});
+            subject.setData({day: 1, month: 6, year: 2018});
 
             const args = subject.vm.dateConstructor;
             const utcTime = Date.UTC(...args);
@@ -346,7 +346,7 @@ describe('components/DateInput', () => {
       describe('setter', () => {
         describe('given a non-Date value', () => {
           it('does nothing', () => {
-            subject.setData({day: 17, month: 5, year: 2018,});
+            subject.setData({day: 17, month: 5, year: 2018});
             subject.vm.date = null;
             expect(subject.vm.day).toBe(17);
             expect(subject.vm.month).toBe(5);
@@ -394,7 +394,7 @@ describe('components/DateInput', () => {
           const secondDate = new Date('1975-04-19');
 
           const subject = createTestSubject(firstDate);
-          subject.setProps({value: secondDate,});
+          subject.setProps({value: secondDate});
 
           expect(mockDateSetter).toHaveBeenCalledTimes(2);
           expect(mockDateSetter).toHaveBeenNthCalledWith(1, firstDate);
@@ -409,7 +409,7 @@ describe('components/DateInput', () => {
           const secondDate = new Date('1960-01-01');
 
           const subject = createTestSubject(firstDate);
-          subject.setProps({value: secondDate,});
+          subject.setProps({value: secondDate});
 
           expect(mockDateSetter).toHaveBeenCalledTimes(1);
           expect(mockDateSetter.mock.calls[0][0]).toBe(firstDate);
@@ -451,7 +451,7 @@ describe('components/DateInput', () => {
       describe('Day input', () => {
         let input;
         beforeEach(() => {
-          input = subject.find({ ref: 'dayInput', });
+          input = subject.find({ ref: 'dayInput' });
         });
 
         describe('is lazily bound to `dayInput`', () => {
@@ -485,12 +485,12 @@ describe('components/DateInput', () => {
 
     describe('given property type="month"', () => {
       beforeEach(() => {
-        subject.setProps({type: 'month',});
+        subject.setProps({type: 'month'});
       });
 
       describe('Day input', () => {
         it('is not rendered', () => {
-          const input = subject.find({ ref: 'dayInput', });
+          const input = subject.find({ ref: 'dayInput' });
           expect(input.exists()).toBe(false);
         });
       });
@@ -499,7 +499,7 @@ describe('components/DateInput', () => {
     describe('Month input', () => {
       let input;
       beforeEach(() => {
-        input = subject.find({ ref: 'monthInput', });
+        input = subject.find({ ref: 'monthInput' });
       });
 
       describe('is lazily bound to `monthInput`', () => {
@@ -533,7 +533,7 @@ describe('components/DateInput', () => {
     describe('Year input', () => {
       let input;
       beforeEach(() => {
-        input = subject.find({ ref: 'yearInput', });
+        input = subject.find({ ref: 'yearInput' });
       });
 
       describe('is lazily bound to `yearInput`', () => {
@@ -574,18 +574,18 @@ describe('components/DateInput', () => {
 
     describe('inputs have globally unique ID attributes', () => {
       it('Day input has a unique ID attribute', () => {
-        const id1 = subject1.find({ref: 'dayInput',}).element.id;
-        const id2 = subject2.find({ref: 'dayInput',}).element.id;
+        const id1 = subject1.find({ref: 'dayInput'}).element.id;
+        const id2 = subject2.find({ref: 'dayInput'}).element.id;
         expect(id1).not.toEqual(id2);
       });
       it('Month input has a unique ID attribute', () => {
-        const id1 = subject1.find({ref: 'monthInput',}).element.id;
-        const id2 = subject2.find({ref: 'monthInput',}).element.id;
+        const id1 = subject1.find({ref: 'monthInput'}).element.id;
+        const id2 = subject2.find({ref: 'monthInput'}).element.id;
         expect(id1).not.toEqual(id2);
       });
       it('Year input has a unique ID attribute', () => {
-        const id1 = subject1.find({ref: 'yearInput',}).element.id;
-        const id2 = subject2.find({ref: 'yearInput',}).element.id;
+        const id1 = subject1.find({ref: 'yearInput'}).element.id;
+        const id2 = subject2.find({ref: 'yearInput'}).element.id;
         expect(id1).not.toEqual(id2);
       });
     });

--- a/hosting/apply/tests/unit/components/FirebaseUI.spec.js
+++ b/hosting/apply/tests/unit/components/FirebaseUI.spec.js
@@ -67,7 +67,7 @@ describe('FirebaseUI component', () => {
         {
           provider: auth.EmailAuthProvider.PROVIDER_ID,
           requireDisplayName: false,
-        }
+        },
       ],
       credentialHelper: firebaseui.auth.CredentialHelper.NONE,
       callbacks: {

--- a/hosting/apply/tests/unit/store.spec.js
+++ b/hosting/apply/tests/unit/store.spec.js
@@ -38,7 +38,7 @@ describe('Vuex store', () => {
     ['auth', auth],
     ['applicant', applicant],
     ['application', application],
-    ['vacancy', vacancy]
+    ['vacancy', vacancy],
   ];
   it.each(modules)('registers module `%s`', (moduleName, module) => {
     expect(store.modules[moduleName]).toBe(module);

--- a/hosting/apply/tests/unit/store/applicant.spec.js
+++ b/hosting/apply/tests/unit/store/applicant.spec.js
@@ -7,7 +7,7 @@ jest.mock('@/firebase', () => {
   const firebase = require('firebase-mock');
   const firestore = firebase.MockFirebaseSdk().firestore();
   firestore.autoFlush();
-  return {firestore,};
+  return {firestore};
 });
 
 describe('store/applicant', () => {
@@ -24,7 +24,7 @@ describe('store/applicant', () => {
   describe('mutations', () => {
     describe('setApplicant', () => {
       it('stores the supplied data in the state', () => {
-        const data = {name: 'John Smith',};
+        const data = {name: 'John Smith'};
         mutations.setApplicant(state, data);
         expect(state.data).toBe(data);
       });
@@ -57,8 +57,8 @@ describe('store/applicant', () => {
 
       describe('applicant exists in Firestore', () => {
         const docId = '4jsbvO27RJYqSRsgZM9sPhDFLDU2';
-        const data = {name: 'John Smith',};
-        const sanitizedData = {name: 'John Smith', sanitized: true,};
+        const data = {name: 'John Smith'};
+        const sanitizedData = {name: 'John Smith', sanitized: true};
 
         beforeEach(async () => {
           getters.applicantDoc = firestore.collection('applicants').doc(docId);
@@ -108,7 +108,7 @@ describe('store/applicant', () => {
 
       describe('happy path', () => {
         const docId = '4jsbvO27RJYqSRsgZM9sPhDFLDU2';
-        const data = {name: 'John Smith',};
+        const data = {name: 'John Smith'};
 
         beforeEach(async () => {
           getters.applicantDoc = firestore.collection('applicants').doc(docId);
@@ -139,7 +139,7 @@ describe('store/applicant', () => {
   describe('getters', () => {
     describe('applicant()', () => {
       beforeEach(() => {
-        state.data = {name: 'John Smith',};
+        state.data = {name: 'John Smith'};
       });
 
       it('is a function (so vuex does not cache output)', () => {

--- a/hosting/apply/tests/unit/store/application.spec.js
+++ b/hosting/apply/tests/unit/store/application.spec.js
@@ -7,7 +7,7 @@ jest.mock('@/firebase', () => {
   const firebase = require('firebase-mock');
   const firestore = firebase.MockFirebaseSdk().firestore();
   firestore.autoFlush();
-  return {firestore,};
+  return {firestore};
 });
 
 describe('store/application', () => {
@@ -25,10 +25,10 @@ describe('store/application', () => {
   describe('mutations', () => {
     describe('setApplication', () => {
       const id = 'abc123';
-      const data = {status: 'draft',};
+      const data = {status: 'draft'};
 
       beforeEach(() => {
-        mutations.setApplication(state, {id, data,});
+        mutations.setApplication(state, {id, data});
       });
 
       it('stores the supplied document ID in the state', () => {
@@ -59,8 +59,8 @@ describe('store/application', () => {
 
       describe('application already exists in Firestore', () => {
         const docId = 'abc123';
-        const data = {state: 'draft',};
-        const sanitizedData = {state: 'draft', sanitized: true, updatedAt: expect.any(Date),};
+        const data = {state: 'draft'};
+        const sanitizedData = {state: 'draft', sanitized: true, updatedAt: expect.any(Date)};
 
         beforeEach(async () => {
           getters.applicantDoc = 'applicants/4jsbvO27RJYqSRsgZM9sPhDFLDU2';
@@ -86,7 +86,7 @@ describe('store/application', () => {
         });
 
         it('commits the document ID and sanitized data', () => {
-          expect(context.commit).toHaveBeenCalledWith('setApplication', {id: docId, data: sanitizedData,});
+          expect(context.commit).toHaveBeenCalledWith('setApplication', {id: docId, data: sanitizedData});
         });
       });
 
@@ -108,7 +108,7 @@ describe('store/application', () => {
               'setApplication',
               {
                 id: null,
-                data: { createdAt: expect.any(Date), state: 'draft', updatedAt: expect.any(Date), },
+                data: { createdAt: expect.any(Date), state: 'draft', updatedAt: expect.any(Date) },
               }
             );
         });
@@ -151,7 +151,7 @@ describe('store/application', () => {
         });
 
         it('saves data to Firestore with `applicant` and `vacancy` relational keys', async () => {
-          const data = {status: 'submitted',};
+          const data = {status: 'submitted'};
           await actions.saveApplication(context, data);
           expect(getters.applicationDoc.set).toHaveBeenCalledTimes(1);
           expect(getters.applicationDoc.set).toHaveBeenCalledWith({
@@ -162,15 +162,15 @@ describe('store/application', () => {
         });
 
         it('does not change the original input data (not passed by reference)', async () => {
-          const data = {status: 'submitted',};
+          const data = {status: 'submitted'};
           await actions.saveApplication(context, data);
-          expect(data).toEqual({status: 'submitted',});
+          expect(data).toEqual({status: 'submitted'});
         });
 
         it('commits the document ID and a copy of the data (not the input object passed by reference)', async () => {
-          const data = {status: 'submitted',};
+          const data = {status: 'submitted'};
           await actions.saveApplication(context, data);
-          expect(context.commit).toHaveBeenCalledWith('setApplication', {id: 'abc123', data,});
+          expect(context.commit).toHaveBeenCalledWith('setApplication', {id: 'abc123', data});
           const committedData = context.commit.mock.calls[0][1].data;
           expect(committedData).not.toBe(data);
         });
@@ -197,7 +197,7 @@ describe('store/application', () => {
   describe('getters', () => {
     describe('application()', () => {
       beforeEach(() => {
-        state.data = {status: 'draft',};
+        state.data = {status: 'draft'};
       });
 
       it('is a function (so vuex does not cache output)', () => {

--- a/hosting/apply/tests/unit/store/auth.spec.js
+++ b/hosting/apply/tests/unit/store/auth.spec.js
@@ -14,7 +14,7 @@ describe('store/auth', () => {
   describe('mutations', () => {
     describe('setCurrentUser', () => {
       it('sets `currentUser` in the state', () => {
-        const data = {uid: 'abc123', email: 'user@example.com',};
+        const data = {uid: 'abc123', email: 'user@example.com'};
         mutations.setCurrentUser(state, data);
         expect(state.currentUser).toBe(data);
       });

--- a/hosting/apply/tests/unit/store/vacancy.spec.js
+++ b/hosting/apply/tests/unit/store/vacancy.spec.js
@@ -7,7 +7,7 @@ jest.mock('@/firebase', () => {
   const firebase = require('firebase-mock');
   const firestore = firebase.MockFirebaseSdk().firestore();
   firestore.autoFlush();
-  return {firestore,};
+  return {firestore};
 });
 
 describe('store/vacancy', () => {
@@ -25,7 +25,7 @@ describe('store/vacancy', () => {
   describe('mutations', () => {
     describe('setVacancy', () => {
       it('stores the supplied data in the state', () => {
-        const data = {title: 'Example Vacancy Title',};
+        const data = {title: 'Example Vacancy Title'};
         mutations.setVacancy(state, data);
         expect(state.data).toBe(data);
       });
@@ -65,8 +65,8 @@ describe('store/vacancy', () => {
 
       describe('happy path', () => {
         const docId = 'hsQqdvAfZpSw94X2B8nA';
-        const data = {title: 'Example Vacancy Title',};
-        const sanitizedData = {title: 'Example Vacancy Title', sanitized: true,};
+        const data = {title: 'Example Vacancy Title'};
+        const sanitizedData = {title: 'Example Vacancy Title', sanitized: true};
 
         beforeEach(async () => {
           state.id = docId;
@@ -99,7 +99,7 @@ describe('store/vacancy', () => {
   describe('getters', () => {
     describe('vacancy', () => {
       it('returns the vacancy data object from state (passed by reference)', () => {
-        const data = {title: 'Example Vacancy Title',};
+        const data = {title: 'Example Vacancy Title'};
         state.data = data;
         expect(getters.vacancy(state)).toBe(data);
       });

--- a/hosting/apply/tests/unit/utils/sanitizeFirestore.spec.js
+++ b/hosting/apply/tests/unit/utils/sanitizeFirestore.spec.js
@@ -52,7 +52,7 @@ describe('utils/sanitizeFirestore', () => {
       },
       emails: [
         'jsmith@gmail.com',
-        'john.smith@outlook.com'
+        'john.smith@outlook.com',
       ],
       qt_passed: true,
       qt_score: 28,
@@ -68,7 +68,7 @@ describe('utils/sanitizeFirestore', () => {
     });
     expect(sanitized.emails).toEqual([
       'jsmith@gmail.com',
-      'john.smith@outlook.com'
+      'john.smith@outlook.com',
     ]);
     expect(sanitized.qt_passed).toEqual(true);
     expect(sanitized.qt_score).toEqual(28);

--- a/hosting/qt-admin/.eslintrc
+++ b/hosting/qt-admin/.eslintrc
@@ -5,18 +5,18 @@
     "jest": true
   },
   "extends": [
-    "plugin:vue/essential",
+    "plugin:vue/recommended",
     "eslint:recommended"
   ],
   "rules": {
-    "comma-dangle": ["error", {
-      "objects": "always"
-    }],
-    "semi": "error",
+    "comma-dangle": ["error", {"arrays": "always-multiline", "objects": "always-multiline"}],
+    "eol-last": ["error", "always"],
     "func-style": ["error", "expression"],
     "prefer-arrow-callback": "error",
-    "quotes": ["error", "single", { "avoidEscape": true}],
-    "eol-last": ["error", "always"]
+    "quotes": ["error", "single", {"avoidEscape": true}],
+    "semi": "error",
+    "vue/component-name-in-template-casing": "error",
+    "vue/script-indent": ["error", 2]
   },
   "parserOptions": {
     "parser": "babel-eslint"

--- a/hosting/qt-admin/babel.config.js
+++ b/hosting/qt-admin/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   presets: [
-    '@vue/app'
+    '@vue/app',
   ],
 };

--- a/hosting/qt-admin/jest.config.js
+++ b/hosting/qt-admin/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
     'js',
     'jsx',
     'json',
-    'vue'
+    'vue',
   ],
   transform: {
     '^.+\\.vue$': 'vue-jest',
@@ -14,19 +14,19 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   snapshotSerializers: [
-    'jest-serializer-vue'
+    'jest-serializer-vue',
   ],
   testMatch: [
-    '**/tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)'
+    '**/tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)',
   ],
   testURL: 'http://localhost/',
   collectCoverage: true,
   collectCoverageFrom: [
-    'src/**/*.{js,vue}'
+    'src/**/*.{js,vue}',
   ],
   coverageReporters: [
     'html',
-    'text-summary'
+    'text-summary',
   ],
   setupTestFrameworkScriptFile: 'jest-extended',
 };

--- a/hosting/qt-admin/src/App.vue
+++ b/hosting/qt-admin/src/App.vue
@@ -6,7 +6,7 @@
 
 <script>
 export default {
-  name: 'app',
+  name: 'App',
 };
 </script>
 

--- a/hosting/qt-admin/src/components/FirebaseUI.vue
+++ b/hosting/qt-admin/src/components/FirebaseUI.vue
@@ -1,45 +1,45 @@
 <template>
-  <div id="firebaseui-auth-container"></div>
+  <div id="firebaseui-auth-container" />
 </template>
 
 <script>
-  import {auth} from '@/firebase';
-  import firebaseui from 'firebaseui';
+import {auth} from '@/firebase';
+import firebaseui from 'firebaseui';
 
-  export default {
-    name: 'FirebaseUI',
-    mounted() {
-      this.ui = new firebaseui.auth.AuthUI(auth());
-      this.ui.start('#firebaseui-auth-container', this.uiConfig);
-    },
-    destroyed() {
-      this.ui.delete();
-    },
-    data() {
-      return {
-        uiConfig: {
-          signInOptions: [
-            {
-              provider: auth.GoogleAuthProvider.PROVIDER_ID,
-              customParameters: {
-                hd: 'judicialappointments.digital',
-              },
-            }
-          ],
-          callbacks: {
-            signInSuccessWithAuthResult: this.signInSuccess,
+export default {
+  name: 'FirebaseUI',
+  data() {
+    return {
+      uiConfig: {
+        signInOptions: [
+          {
+            provider: auth.GoogleAuthProvider.PROVIDER_ID,
+            customParameters: {
+              hd: 'judicialappointments.digital',
+            },
           },
+        ],
+        callbacks: {
+          signInSuccessWithAuthResult: this.signInSuccess,
         },
-      };
-    },
-    methods: {
-      signInSuccess(authResult) {
-        this.$emit('signInSuccess', authResult);
-        // Return false to disable FirebaseUI auth redirect
-        return false;
       },
+    };
+  },
+  mounted() {
+    this.ui = new firebaseui.auth.AuthUI(auth());
+    this.ui.start('#firebaseui-auth-container', this.uiConfig);
+  },
+  destroyed() {
+    this.ui.delete();
+  },
+  methods: {
+    signInSuccess(authResult) {
+      this.$emit('signInSuccess', authResult);
+      // Return false to disable FirebaseUI auth redirect
+      return false;
     },
-  };
+  },
+};
 </script>
 
 <style src="firebaseui/dist/firebaseui.css"></style>

--- a/hosting/qt-admin/src/router.js
+++ b/hosting/qt-admin/src/router.js
@@ -28,7 +28,7 @@ const router = new Router({
       beforeEnter: (to, from, next) => {
         const isSignedIn = store.getters.isSignedIn;
         if(isSignedIn) {
-          return next({name: 'dashboard',});
+          return next({name: 'dashboard'});
         }
 
         return next();
@@ -42,12 +42,12 @@ const router = new Router({
         const isSignedIn = store.getters.isSignedIn;
         const emailDomainIsValid = store.getters.emailDomainIsValid;
         if(isSignedIn && emailDomainIsValid) {
-          return next({name: 'dashboard',});
+          return next({name: 'dashboard'});
         }
 
         return next();
       },
-    }
+    },
   ],
 });
 
@@ -63,11 +63,11 @@ router.beforeEach((to, from, next) => {
   const emailDomainIsValid = store.getters.emailDomainIsValid;
 
   if (requiresAuth && !isSignedIn) {
-    return next({name: 'sign-in',});
+    return next({name: 'sign-in'});
   } 
 
   if (requiresAuth && !emailDomainIsValid) {
-    return next({name: 'invalid-domain',});
+    return next({name: 'invalid-domain'});
   }
 
   return next();

--- a/hosting/qt-admin/src/store/auth.js
+++ b/hosting/qt-admin/src/store/auth.js
@@ -8,7 +8,7 @@ const module = {
     },
   },
   actions: {
-    setCurrentUser({commit,}, user) {
+    setCurrentUser({commit}, user) {
       if (user === null) {
         commit('setCurrentUser', null);
       } else {

--- a/hosting/qt-admin/src/views/Dashboard.vue
+++ b/hosting/qt-admin/src/views/Dashboard.vue
@@ -2,14 +2,28 @@
   <div>
     <nav class="navbar navbar-expand-sm navbar-light bg-light mb-4">
       <div class="container">
-        <a href="/" class="navbar-brand router-link-active">
-          <img src="@/assets/jac-logo.svg" alt="Judicial Appointments Commission" width="197" height="66">
+        <a
+          href="/"
+          class="navbar-brand router-link-active"
+        >
+          <img
+            src="@/assets/jac-logo.svg"
+            alt="Judicial Appointments Commission"
+            width="197"
+            height="66"
+          >
         </a>
 
         <div class="navbar-collapse">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <button class="btn btn-link" id="sign-out" @click="signOut">Sign out</button>
+              <button
+                id="sign-out"
+                class="btn btn-link"
+                @click="signOut"
+              >
+                Sign out
+              </button>
             </li>
           </ul>
         </div>
@@ -17,7 +31,9 @@
     </nav>
 
     <div class="container-fluid">
-      <h1 class="text-center">Hello, admin</h1>
+      <h1 class="text-center">
+        Hello, admin
+      </h1>
 
       <p>This is admin dashboard page </p>
     </div>    
@@ -25,14 +41,14 @@
 </template>
 
 <script>
-  import { auth } from '@/firebase';
+import { auth } from '@/firebase';
 
-  export default {
-    methods: {
-      signOut() {
-        auth().signOut();
-        this.$router.go('/sign-in');
-      },
+export default {
+  methods: {
+    signOut() {
+      auth().signOut();
+      this.$router.go('/sign-in');
     },
-  };
+  },
+};
 </script>

--- a/hosting/qt-admin/src/views/InvalidDomain.vue
+++ b/hosting/qt-admin/src/views/InvalidDomain.vue
@@ -2,14 +2,24 @@
   <div>
     <nav class="navbar navbar-expand-sm navbar-light bg-light mb-4">
       <div class="container">
-        <a href="/" class="navbar-brand router-link-active">
-          <img src="@/assets/jac-logo.svg" alt="Judicial Appointments Commission" width="197" height="66">
+        <a
+          href="/"
+          class="navbar-brand router-link-active"
+        >
+          <img
+            src="@/assets/jac-logo.svg"
+            alt="Judicial Appointments Commission"
+            width="197"
+            height="66"
+          >
         </a>
       </div>
     </nav>
 
     <div class="container-fluid">
-      <h1 class="text-center">Invalid email domain</h1>
+      <h1 class="text-center">
+        Invalid email domain
+      </h1>
 
       <p>Please sign in with your judicialappointments.digital Google account</p>
     </div>    

--- a/hosting/qt-admin/src/views/SignIn.vue
+++ b/hosting/qt-admin/src/views/SignIn.vue
@@ -2,28 +2,35 @@
   <div class="mt-3">
     <div class="login-container text-center">
       <div class="mb-3 mt-5">
-        <img src="@/assets/jac-logo.svg" alt="Judicial Appointments Commission" width="197" height="66">
+        <img
+          src="@/assets/jac-logo.svg"
+          alt="Judicial Appointments Commission"
+          width="197"
+          height="66"
+        >
       </div>
-      <p class="mb-4 mt-5">Sign in to admin dashboard with your judicialappointments.digital Google account</p>
+      <p class="mb-4 mt-5">
+        Sign in to admin dashboard with your judicialappointments.digital Google account
+      </p>
       <FirebaseUI @signInSuccess="loginRedirect" />
     </div>
   </div>
 </template>
 
 <script>
-  import FirebaseUI from '@/components/FirebaseUI';
+import FirebaseUI from '@/components/FirebaseUI';
 
-  export default {
-    components: {
-      FirebaseUI,
-    } ,
-    methods: {
-      loginRedirect(authResult) {
-        this.$store.dispatch('setCurrentUser', authResult.user);
-        this.$router.push('/');
-      },
+export default {
+  components: {
+    FirebaseUI,
+  } ,
+  methods: {
+    loginRedirect(authResult) {
+      this.$store.dispatch('setCurrentUser', authResult.user);
+      this.$router.push('/');
     },
-  };
+  },
+};
 </script>
 
 <style scoped>

--- a/hosting/qt-admin/tests/unit/componentns/FirebaseUI.spec.js
+++ b/hosting/qt-admin/tests/unit/componentns/FirebaseUI.spec.js
@@ -63,8 +63,8 @@ describe('FirebaseUI component', () => {
       signInOptions: [
         {
           provider: auth.GoogleAuthProvider.PROVIDER_ID,
-          customParameters: {hd: 'judicialappointments.digital',},
-        }
+          customParameters: {hd: 'judicialappointments.digital'},
+        },
       ],
       callbacks: {
         signInSuccessWithAuthResult: wrapper.vm.signInSuccess,

--- a/hosting/qt-admin/tests/unit/store/auth.spec.js
+++ b/hosting/qt-admin/tests/unit/store/auth.spec.js
@@ -16,7 +16,7 @@ describe('store/auth', () => {
 
     describe('setCurrentUser', () => {
       it('sets currentUser in the state', () => {
-        const data = {uid: '12345', email: 'test@test.com',};
+        const data = {uid: '12345', email: 'test@test.com'};
         mutations.setCurrentUser(state, data);
         expect(state.currentUser).toBe(data);
       });

--- a/hosting/qt-admin/tests/unit/views/Dashboard.spec.js
+++ b/hosting/qt-admin/tests/unit/views/Dashboard.spec.js
@@ -21,7 +21,7 @@ describe('Dashboard view', () => {
   });
 
   it('calls signOut methods', () => {
-    wrapper.setMethods({ signOut:jest.fn(), });
+    wrapper.setMethods({ signOut: jest.fn() });
     wrapper.find('button#sign-out').trigger('click');
 
     expect(wrapper.vm.signOut).toHaveBeenCalledTimes(1);

--- a/hosting/qt/.eslintrc
+++ b/hosting/qt/.eslintrc
@@ -5,18 +5,18 @@
     "jest": true
   },
   "extends": [
-    "plugin:vue/essential",
+    "plugin:vue/recommended",
     "eslint:recommended"
   ],
   "rules": {
-    "comma-dangle": ["error", {
-      "objects": "always"
-    }],
-    "semi": "error",
+    "comma-dangle": ["error", {"arrays": "always-multiline", "objects": "always-multiline"}],
+    "eol-last": ["error", "always"],
     "func-style": ["error", "expression"],
     "prefer-arrow-callback": "error",
-    "quotes": ["error", "single", { "avoidEscape": true}],
-    "eol-last": ["error", "always"]
+    "quotes": ["error", "single", {"avoidEscape": true}],
+    "semi": "error",
+    "vue/component-name-in-template-casing": "error",
+    "vue/script-indent": ["error", 2]
   },
   "parserOptions": {
     "parser": "babel-eslint"

--- a/hosting/qt/babel.config.js
+++ b/hosting/qt/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   presets: [
-    '@vue/app'
+    '@vue/app',
   ],
 };

--- a/hosting/qt/jest.config.js
+++ b/hosting/qt/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
     'js',
     'jsx',
     'json',
-    'vue'
+    'vue',
   ],
   transform: {
     '^.+\\.vue$': 'vue-jest',
@@ -14,19 +14,19 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   snapshotSerializers: [
-    'jest-serializer-vue'
+    'jest-serializer-vue',
   ],
   testMatch: [
-    '**/tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)'
+    '**/tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)',
   ],
   testURL: 'http://localhost/',
   collectCoverage: true,
   collectCoverageFrom: [
-    'src/**/*.{js,vue}'
+    'src/**/*.{js,vue}',
   ],
   coverageReporters: [
     'html',
-    'text-summary'
+    'text-summary',
   ],
   setupTestFrameworkScriptFile: 'jest-extended',
 };

--- a/hosting/qt/src/App.vue
+++ b/hosting/qt/src/App.vue
@@ -1,14 +1,32 @@
 <template>
-  <div id="app" class="mb-5">
-    <nav class="navbar navbar-expand-sm navbar-light bg-light mb-4" v-if="isSignedIn">
+  <div
+    id="app"
+    class="mb-5"
+  >
+    <nav
+      v-if="isSignedIn"
+      class="navbar navbar-expand-sm navbar-light bg-light mb-4"
+    >
       <div class="container">
-        <RouterLink to="/" class="navbar-brand">
-          <img src="@/assets/jac-logo.svg" alt="Judicial Appointments Commission" width="197" height="66">
+        <RouterLink
+          to="/"
+          class="navbar-brand"
+        >
+          <img
+            src="@/assets/jac-logo.svg"
+            alt="Judicial Appointments Commission"
+            width="197"
+            height="66"
+          >
         </RouterLink>
         <div class="navbar-collapse">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <a class="nav-link" href="#" @click.prevent="signOut">Sign out</a>
+              <a
+                class="nav-link"
+                href="#"
+                @click.prevent="signOut"
+              >Sign out</a>
             </li>
           </ul>
         </div>
@@ -20,28 +38,28 @@
 </template>
 
 <script>
-  import { mapGetters } from 'vuex';
-  import { auth } from '@/firebase';
+import { mapGetters } from 'vuex';
+import { auth } from '@/firebase';
 
-  export default {
-    methods: {
-      signOut() {
-        auth().signOut();
-      },
+export default {
+  methods: {
+    signOut() {
+      auth().signOut();
     },
-    computed: {
-      ...mapGetters([
-        'isSignedIn'
-      ]),
+  },
+  computed: {
+    ...mapGetters([
+      'isSignedIn',
+    ]),
+  },
+  watch: {
+    isSignedIn(signedIn) {
+      if (signedIn === false) {
+        this.$router.push({name: 'sign-in'});
+      }
     },
-    watch: {
-      isSignedIn(signedIn) {
-        if (signedIn === false) {
-          this.$router.push({name: 'sign-in',});
-        }
-      },
-    },
-  };
+  },
+};
 </script>
 
 <style lang="scss">

--- a/hosting/qt/src/App.vue
+++ b/hosting/qt/src/App.vue
@@ -42,11 +42,6 @@ import { mapGetters } from 'vuex';
 import { auth } from '@/firebase';
 
 export default {
-  methods: {
-    signOut() {
-      auth().signOut();
-    },
-  },
   computed: {
     ...mapGetters([
       'isSignedIn',
@@ -57,6 +52,11 @@ export default {
       if (signedIn === false) {
         this.$router.push({name: 'sign-in'});
       }
+    },
+  },
+  methods: {
+    signOut() {
+      auth().signOut();
     },
   },
 };

--- a/hosting/qt/src/components/FirebaseUI.vue
+++ b/hosting/qt/src/components/FirebaseUI.vue
@@ -1,44 +1,44 @@
 <template>
-  <div id="firebaseui-auth-container"></div>
+  <div id="firebaseui-auth-container" />
 </template>
 
 <script>
-  import {auth} from '@/firebase';
-  import firebaseui from 'firebaseui';
+import {auth} from '@/firebase';
+import firebaseui from 'firebaseui';
 
-  export default {
-    name: 'FirebaseUI',
-    mounted() {
-      this.ui = new firebaseui.auth.AuthUI(auth());
-      this.ui.start('#firebaseui-auth-container', this.uiConfig);
-    },
-    destroyed() {
-      this.ui.delete();
-    },
-    data() {
-      return {
-        uiConfig: {
-          signInOptions: [
-            {
-              provider: auth.EmailAuthProvider.PROVIDER_ID,
-              requireDisplayName: true,
-            }
-          ],
-          credentialHelper: firebaseui.auth.CredentialHelper.NONE,
-          callbacks: {
-            signInSuccessWithAuthResult: this.signInSuccess,
+export default {
+  name: 'FirebaseUI',
+  data() {
+    return {
+      uiConfig: {
+        signInOptions: [
+          {
+            provider: auth.EmailAuthProvider.PROVIDER_ID,
+            requireDisplayName: true,
           },
+        ],
+        credentialHelper: firebaseui.auth.CredentialHelper.NONE,
+        callbacks: {
+          signInSuccessWithAuthResult: this.signInSuccess,
         },
-      };
-    },
-    methods: {
-      signInSuccess(authResult) {
-        this.$emit('signInSuccess', authResult);
-        // Return false to disable FirebaseUI auth redirect
-        return false;
       },
+    };
+  },
+  mounted() {
+    this.ui = new firebaseui.auth.AuthUI(auth());
+    this.ui.start('#firebaseui-auth-container', this.uiConfig);
+  },
+  destroyed() {
+    this.ui.delete();
+  },
+  methods: {
+    signInSuccess(authResult) {
+      this.$emit('signInSuccess', authResult);
+      // Return false to disable FirebaseUI auth redirect
+      return false;
     },
-  };
+  },
+};
 </script>
 
 <style src="firebaseui/dist/firebaseui.css"></style>

--- a/hosting/qt/src/components/IEWarning.vue
+++ b/hosting/qt/src/components/IEWarning.vue
@@ -1,5 +1,9 @@
 <template>
-  <div v-if="isIE" class="alert alert-danger mt-5 mb-5" role="alert">
+  <div
+    v-if="isIE"
+    class="alert alert-danger mt-5 mb-5"
+    role="alert"
+  >
     <h4>Warning</h4>
     <p><strong>You’re using Internet Explorer.</strong></p>
     <p>The test will not work correctly on this browser – use Chrome, Firefox or Microsoft Edge instead.</p>
@@ -7,13 +11,13 @@
 </template>
 
 <script>
-  export default {
-    data() {
-      return {
-        // Detect whether we're in Internet Explorer by checking for the existence of `document.documentMode`
-        // `document.documentMode` is only present in IE. For every other browser it's undefined.
-        isIE: !!document.documentMode,
-      };
-    },
-  };
+export default {
+  data() {
+    return {
+      // Detect whether we're in Internet Explorer by checking for the existence of `document.documentMode`
+      // `document.documentMode` is only present in IE. For every other browser it's undefined.
+      isIE: !!document.documentMode,
+    };
+  },
+};
 </script>

--- a/hosting/qt/src/components/TestCard.vue
+++ b/hosting/qt/src/components/TestCard.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="card">
     <div class="card-body">
-      <h5 class="card-title">{{test.title}}</h5>
+      <h5 class="card-title">
+        {{ test.title }}
+      </h5>
 
       <p>
         There are 20 multiple choice questions of equal weight. Each question presents a hypothetical situation that you might
@@ -13,10 +15,19 @@
       </p>
 
       <div v-if="testIsOpen">
-        <hr />
+        <hr>
         <div class="custom-control custom-checkbox mb-3">
-          <input type="checkbox" id="terms" class="custom-control-input" v-model="termsAgreed" :disabled="userHasStartedTest">
-          <label for="terms" class="custom-control-label">
+          <input
+            id="terms"
+            v-model="termsAgreed"
+            type="checkbox"
+            class="custom-control-input"
+            :disabled="userHasStartedTest"
+          >
+          <label
+            for="terms"
+            class="custom-control-label"
+          >
             I confirm that I will keep this test confidential and not share the scenario or questions at any point during or after
             the selection exercise.
           </label>
@@ -27,19 +38,29 @@
         </div>
 
         <div v-else-if="userHasStartedTest">
-          <button type="button" class="btn btn-primary" @click="openForm">
+          <button
+            type="button"
+            class="btn btn-primary"
+            @click="openForm"
+          >
             Return to test
           </button>
         </div>
 
         <div v-else>
-          <button type="button" class="btn btn-primary mr-2"
-                  @click="start"
-                  :disabled="!termsAgreed || isStarting"
-                  :class="{isStarting}">
+          <button
+            type="button"
+            class="btn btn-primary mr-2"
+            :disabled="!termsAgreed || isStarting"
+            :class="{isStarting}"
+            @click="start"
+          >
             Start test
           </button>
-          <span class="spinner-border spinner-border-sm text-secondary" v-if="isStarting"></span>
+          <span
+            v-if="isStarting"
+            class="spinner-border spinner-border-sm text-secondary"
+          />
         </div>
       </div>
     </div>
@@ -47,53 +68,53 @@
 </template>
 
 <script>
-  import { mapGetters } from 'vuex';
+import { mapGetters } from 'vuex';
 
-  export default {
-    props: {},
-    data() {
-      return {
-        isStarting: false,
-        termsAgreedCheckbox: false,
-      };
-    },
-    computed: {
-      ...mapGetters([
-        'test',
-        'testIsOpen',
-        'testFormUrl',
-        'userHasStartedTest',
-        'userHasFinishedTest'
-      ]),
-      termsAgreed: {
-        get() {
-          const started = this.userHasStartedTest;
-          const checkbox = this.termsAgreedCheckbox;
-          return started || checkbox;
-        },
-        set(value) {
-          if (!this.userHasStartedTest) {
-            this.termsAgreedCheckbox = value;
-          }
-        },
+export default {
+  props: {},
+  data() {
+    return {
+      isStarting: false,
+      termsAgreedCheckbox: false,
+    };
+  },
+  computed: {
+    ...mapGetters([
+      'test',
+      'testIsOpen',
+      'testFormUrl',
+      'userHasStartedTest',
+      'userHasFinishedTest',
+    ]),
+    termsAgreed: {
+      get() {
+        const started = this.userHasStartedTest;
+        const checkbox = this.termsAgreedCheckbox;
+        return started || checkbox;
+      },
+      set(value) {
+        if (!this.userHasStartedTest) {
+          this.termsAgreedCheckbox = value;
+        }
       },
     },
-    methods: {
-      start() {
-        this.isStarting = true;
-        return this.$store
-          .dispatch('startTest')
-          .then(this.hasStarted);
-      },
-      hasStarted() {
-        this.isStarting = false;
-        this.openForm();
-      },
-      openForm() {
-        window.location.href = this.testFormUrl;
-      },
+  },
+  methods: {
+    start() {
+      this.isStarting = true;
+      return this.$store
+        .dispatch('startTest')
+        .then(this.hasStarted);
     },
-  };
+    hasStarted() {
+      this.isStarting = false;
+      this.openForm();
+    },
+    openForm() {
+      window.location.href = this.testFormUrl;
+    },
+  },
+};
 </script>
 
 <style scoped>

--- a/hosting/qt/src/components/TestWindow.vue
+++ b/hosting/qt/src/components/TestWindow.vue
@@ -1,79 +1,79 @@
 <template>
   <div>
     <p v-if="beforeTestDay">
-      The test window will be open on {{testDate}} {{timeWindow}}.
+      The test window will be open on {{ testDate }} {{ timeWindow }}.
     </p>
 
     <p v-if="isTestDay && !testHasOpened">
-      The test window will be open today {{timeWindow}}.
+      The test window will be open today {{ timeWindow }}.
     </p>
 
     <template v-if="testIsOpen">
       <p>
-        The test window is now open and closes at {{formatTime(closingTime)}}.
+        The test window is now open and closes at {{ formatTime(closingTime) }}.
       </p>
       <p>
-        Start the test no later than {{formatTime(closingTime.subtract(1, 'hour'))}}
+        Start the test no later than {{ formatTime(closingTime.subtract(1, 'hour')) }}
         to give yourself time to complete it before the window closes.
       </p>
     </template>
 
     <p v-if="isTestDay && testHasClosed">
-      This test has closed. The test window was today {{timeWindow}}.
+      This test has closed. The test window was today {{ timeWindow }}.
     </p>
 
     <p v-if="afterTestDay">
-      This test has closed. The test window was {{testDate}} {{timeWindow}}.
+      This test has closed. The test window was {{ testDate }} {{ timeWindow }}.
     </p>
   </div>
 </template>
 
 <script>
-  import { mapGetters } from 'vuex';
-  import dayjs from 'dayjs';
+import { mapGetters } from 'vuex';
+import dayjs from 'dayjs';
 
-  export default {
-    computed: {
-      ...mapGetters([
-        'test',
-        'testHasOpened',
-        'testHasClosed',
-        'testIsOpen'
-      ]),
-      openingTime() {
-        return dayjs(this.test.openingTime);
-      },
-      closingTime() {
-        return dayjs(this.test.closingTime);
-      },
-      now() {
-        return dayjs();
-      },
-      beforeTestDay() {
-        return this.now.isBefore(this.openingTime, 'day');
-      },
-      isTestDay() {
-        return this.now.isSame(this.openingTime, 'day');
-      },
-      afterTestDay() {
-        return this.now.isAfter(this.openingTime, 'day');
-      },
-      testDate() {
-        return this.formatDate(this.openingTime);
-      },
-      timeWindow() {
-        const openingTime = this.formatTime(this.openingTime);
-        const closingTime = this.formatTime(this.closingTime);
-        return `between ${openingTime} and ${closingTime}`;
-      },
+export default {
+  computed: {
+    ...mapGetters([
+      'test',
+      'testHasOpened',
+      'testHasClosed',
+      'testIsOpen',
+    ]),
+    openingTime() {
+      return dayjs(this.test.openingTime);
     },
-    methods: {
-      formatDate(date) {
-        return date.format('D MMMM YYYY');
-      },
-      formatTime(date) {
-        return date.format('ha');
-      },
+    closingTime() {
+      return dayjs(this.test.closingTime);
     },
-  };
+    now() {
+      return dayjs();
+    },
+    beforeTestDay() {
+      return this.now.isBefore(this.openingTime, 'day');
+    },
+    isTestDay() {
+      return this.now.isSame(this.openingTime, 'day');
+    },
+    afterTestDay() {
+      return this.now.isAfter(this.openingTime, 'day');
+    },
+    testDate() {
+      return this.formatDate(this.openingTime);
+    },
+    timeWindow() {
+      const openingTime = this.formatTime(this.openingTime);
+      const closingTime = this.formatTime(this.closingTime);
+      return `between ${openingTime} and ${closingTime}`;
+    },
+  },
+  methods: {
+    formatDate(date) {
+      return date.format('D MMMM YYYY');
+    },
+    formatTime(date) {
+      return date.format('ha');
+    },
+  },
+};
 </script>

--- a/hosting/qt/src/router.js
+++ b/hosting/qt/src/router.js
@@ -38,7 +38,7 @@ const router = new Router({
 
         if (!isSignedIn) {
           // User must be logged in
-          return next({name: 'sign-in',});
+          return next({name: 'sign-in'});
         }
 
         if (isEmailVerified) {
@@ -52,13 +52,13 @@ const router = new Router({
     {
       path: '*',
       redirect: '/take-test/Q3QPebYC4it3Orp4RtA7',
-    }
+    },
   ],
   scrollBehavior(to, from, savedPosition) {
     if (savedPosition) {
       return savedPosition;
     } else {
-      return {x: 0, y: 0,};
+      return {x: 0, y: 0};
     }
   },
 });
@@ -77,12 +77,12 @@ router.beforeEach((to, from, next) => {
 
   if (requiresAuth && !isSignedIn) {
     // User must be logged in
-    return next({name: 'sign-in',});
+    return next({name: 'sign-in'});
   }
 
   if (requiresAuth && !isEmailVerified) {
     // User must verify their email address
-    return next({name: 'verify-email',});
+    return next({name: 'verify-email'});
   }
 
   return next();

--- a/hosting/qt/src/sentry.js
+++ b/hosting/qt/src/sentry.js
@@ -7,7 +7,7 @@ const initSentry = () => {
   Sentry.init({
     dsn: 'https://2ae111f2a62d4f7bbe84aaf868f0f0d5@sentry.io/1472344',
     environment: process.env.NODE_ENV,
-    integrations: [new Integrations.Vue({Vue, attachProps: true,})],
+    integrations: [new Integrations.Vue({Vue, attachProps: true})],
   });
   setUserScope();
 };

--- a/hosting/qt/src/store/auth.js
+++ b/hosting/qt/src/store/auth.js
@@ -8,7 +8,7 @@ const module = {
     },
   },
   actions: {
-    setCurrentUser({commit,}, user) {
+    setCurrentUser({commit}, user) {
       if (user === null) {
         commit('setCurrentUser', null);
       } else {

--- a/hosting/qt/src/store/test.js
+++ b/hosting/qt/src/store/test.js
@@ -15,7 +15,7 @@ const module = {
     },
   },
   actions: {
-    async loadTest({commit, getters,}) {
+    async loadTest({commit, getters}) {
       const document = getters.testDoc;
       if (!document) throw new Error('Set a test ID before trying to load it');
       const snapshot = await document.get();

--- a/hosting/qt/src/store/userTest.js
+++ b/hosting/qt/src/store/userTest.js
@@ -13,7 +13,7 @@ const commitSnapshot = (commit, snapshot) => {
     delete data.userUid;
     delete data.test;
     data = sanitizeFirestore(data);
-    commit('setUserTest', {id: snapshot.id, data,});
+    commit('setUserTest', {id: snapshot.id, data});
   } else {
     commit('clearUserTest');
   }
@@ -29,13 +29,13 @@ const module = {
       state.id = null;
       state.data = {};
     },
-    setUserTest(state, {id, data,}) {
+    setUserTest(state, {id, data}) {
       state.id = id;
       state.data = data;
     },
   },
   actions: {
-    async loadUserTest({commit, getters,}) {
+    async loadUserTest({commit, getters}) {
       const results = await firestoreCollection()
         .where('test', '==', getters.testDoc)
         .where('userUid', '==', getters.currentUserId)
@@ -48,7 +48,7 @@ const module = {
         commitSnapshot(commit, snapshot);
       }
     },
-    subscribeUserTest({commit, getters,}) {
+    subscribeUserTest({commit, getters}) {
       if (typeof unsubscribe == 'function') return; // Don't subscribe again if already subscribed
       unsubscribe = getters.userTestDoc.onSnapshot((snapshot) => {
         if (!snapshot.metadata.hasPendingWrites && !snapshot.metadata.fromCache) {
@@ -60,7 +60,7 @@ const module = {
       if (typeof unsubscribe === 'function') unsubscribe();
       unsubscribe = undefined; // Reset so we can subscribe again
     },
-    async startTest({commit, getters,}) {
+    async startTest({commit, getters}) {
       const doc = getters.userTestDoc;
 
       // Save the startedAt timestamp to Firestore

--- a/hosting/qt/src/views/SignIn.vue
+++ b/hosting/qt/src/views/SignIn.vue
@@ -2,7 +2,12 @@
   <main class="mt-3">
     <div class="login-container">
       <div class="text-center mb-3 mt-5">
-        <img src="@/assets/jac-logo.svg" alt="Judicial Appointments Commission" width="197" height="66">
+        <img
+          src="@/assets/jac-logo.svg"
+          alt="Judicial Appointments Commission"
+          width="197"
+          height="66"
+        >
       </div>
       <IEWarning />
       <p>To take this test, set up an account with the email address you used for your application and then choose a password.</p>
@@ -12,21 +17,21 @@
 </template>
 
 <script>
-  import FirebaseUI from '@/components/FirebaseUI';
-  import IEWarning from '@/components/IEWarning';
+import FirebaseUI from '@/components/FirebaseUI';
+import IEWarning from '@/components/IEWarning';
 
-  export default {
-    components: {
-      FirebaseUI,
-      IEWarning,
+export default {
+  components: {
+    FirebaseUI,
+    IEWarning,
+  },
+  methods: {
+    loginRedirect(authResult) {
+      this.$store.dispatch('setCurrentUser', authResult.user);
+      this.$router.push('/');
     },
-    methods: {
-      loginRedirect(authResult) {
-        this.$store.dispatch('setCurrentUser', authResult.user);
-        this.$router.push('/');
-      },
-    },
-  };
+  },
+};
 </script>
 
 <style scoped>

--- a/hosting/qt/src/views/TakeTest.vue
+++ b/hosting/qt/src/views/TakeTest.vue
@@ -73,23 +73,6 @@ export default {
       isStarting: false,
     };
   },
-  methods: {
-    loadTestData() {
-      this.$store.commit('setTestId', this.$route.params.id);
-      return Promise.all([
-        this.$store.dispatch('loadTest'),
-        this.$store.dispatch('loadUserTest'),
-      ])
-        .then(() => {
-          this.loaded = true;
-          this.$store.dispatch('subscribeUserTest');
-        })
-        .catch((e) => {
-          this.loadFailed = true;
-          throw e;
-        });
-    },
-  },
   computed: {
     ...mapGetters([
       'test',
@@ -110,6 +93,23 @@ export default {
   },
   destroyed() {
     this.$store.dispatch('unsubscribeUserTest');
+  },
+  methods: {
+    loadTestData() {
+      this.$store.commit('setTestId', this.$route.params.id);
+      return Promise.all([
+        this.$store.dispatch('loadTest'),
+        this.$store.dispatch('loadUserTest'),
+      ])
+        .then(() => {
+          this.loaded = true;
+          this.$store.dispatch('subscribeUserTest');
+        })
+        .catch((e) => {
+          this.loadFailed = true;
+          throw e;
+        });
+    },
   },
 };
 </script>

--- a/hosting/qt/src/views/VerifyEmail.vue
+++ b/hosting/qt/src/views/VerifyEmail.vue
@@ -2,7 +2,7 @@
   <main class="container">
     <h1>Verify your email address</h1>
     <p>We need to make sure we have the right email address for you before you can start your qualifying test.</p>
-    <p>We’ve sent an email to <strong>{{email}}</strong> containing a link. Click the link to verify your email address.</p>
+    <p>We’ve sent an email to <strong>{{ email }}</strong> containing a link. Click the link to verify your email address.</p>
 
     <details>
       <summary>I haven’t got the email yet</summary>
@@ -10,10 +10,18 @@
         <p>It could take up to 2 minutes for the email to arrive.</p>
         <p>Check your ‘spam’ or ‘junk mail’ folder in case it didn’t go into your inbox.</p>
         <p>If it still hasn’t arrived after 2 minutes, click ‘resend email’:</p>
-        <button class="btn btn-primary" type="button" :disabled="sendInProgress" @click.prevent="sendVerificationEmail">
+        <button
+          class="btn btn-primary"
+          type="button"
+          :disabled="sendInProgress"
+          @click.prevent="sendVerificationEmail"
+        >
           Resend email
         </button>
-        <span class="spinner-border spinner-border-sm text-secondary ml-2" v-if="sendInProgress"></span>
+        <span
+          v-if="sendInProgress"
+          class="spinner-border spinner-border-sm text-secondary ml-2"
+        />
       </section>
     </details>
   </main>
@@ -22,23 +30,23 @@
 <script>
 import {functions} from '@/firebase';
 
-  export default {
-    data() {
-      return {
-        email: this.$store.getters.currentUserEmail,
-        sendInProgress: false,
-      };
+export default {
+  data() {
+    return {
+      email: this.$store.getters.currentUserEmail,
+      sendInProgress: false,
+    };
+  },
+  methods: {
+    sendVerificationEmail() {
+      const send = functions().httpsCallable('sendVerificationEmail');
+      this.sendInProgress = true;
+      send().finally(() => {
+        this.sendInProgress = false;
+      });
     },
-    methods: {
-      sendVerificationEmail() {
-        const send = functions().httpsCallable('sendVerificationEmail');
-        this.sendInProgress = true;
-        send().finally(() => {
-          this.sendInProgress = false;
-        });
-      },
-    },
-  };
+  },
+};
 </script>
 
 <style scoped>

--- a/hosting/qt/tests/unit/components/FirebaseUI.spec.js
+++ b/hosting/qt/tests/unit/components/FirebaseUI.spec.js
@@ -67,7 +67,7 @@ describe('FirebaseUI component', () => {
         {
           provider: auth.EmailAuthProvider.PROVIDER_ID,
           requireDisplayName: true,
-        }
+        },
       ],
       credentialHelper: firebaseui.auth.CredentialHelper.NONE,
       callbacks: {

--- a/hosting/qt/tests/unit/components/TestCard.spec.js
+++ b/hosting/qt/tests/unit/components/TestCard.spec.js
@@ -68,7 +68,7 @@ describe.skip('components/TestCard', () => {
 
       describe('when the start button is clicked', () => {
         it.skip('starts the timer and opens the test form', () => {
-          wrapper.setMethods({start: jest.fn(),});
+          wrapper.setMethods({start: jest.fn()});
           wrapper.find('button').trigger('click');
           expect(wrapper.vm.start).toHaveBeenCalledTimes(1);
         });
@@ -113,7 +113,7 @@ describe.skip('components/TestCard', () => {
 
       describe('when the button is clicked', () => {
         it('opens the test form', () => {
-          wrapper.setMethods({openForm: jest.fn(),});
+          wrapper.setMethods({openForm: jest.fn()});
           wrapper.find('button').trigger('click');
           expect(wrapper.vm.openForm).toHaveBeenCalled();
         });
@@ -213,23 +213,23 @@ describe.skip('components/TestCard', () => {
         [
           'canBeStarted',
           'qtPhaseCanBeStarted',
-          true
+          true,
         ],
         [
           'hasBeenStarted',
           'qtPhaseHasBeenStarted',
-          true
+          true,
         ],
         [
           'hasBeenFinished',
           'qtPhaseHasBeenFinished',
-          true
+          true,
         ],
         [
           'formUrl',
           'qtPhaseFormUrl',
-          'https://google.com'
-        ]
+          'https://google.com',
+        ],
       ];
 
       describe.each(dynamicGetters)('`%s`', (field, getter, value) => {

--- a/hosting/qt/tests/unit/components/TestWindow.spec.js
+++ b/hosting/qt/tests/unit/components/TestWindow.spec.js
@@ -24,7 +24,7 @@ describe('components/TestWindow', () => {
         ...mockGetters,
       },
     });
-    return shallowMount(TestWindow, {localVue, store,});
+    return shallowMount(TestWindow, {localVue, store});
   };
 
   afterEach(() => {

--- a/hosting/qt/tests/unit/store.spec.js
+++ b/hosting/qt/tests/unit/store.spec.js
@@ -21,7 +21,7 @@ describe('Vuex store', () => {
   });
 
   const modules = [
-    ['auth', auth]
+    ['auth', auth],
   ];
   it.each(modules)('registers module `%s`', (moduleName, module) => {
     expect(store.modules[moduleName]).toBe(module);

--- a/hosting/qt/tests/unit/store/auth.spec.js
+++ b/hosting/qt/tests/unit/store/auth.spec.js
@@ -14,7 +14,7 @@ describe('store/auth', () => {
   describe('mutations', () => {
     describe('setCurrentUser', () => {
       it('sets `currentUser` in the state', () => {
-        const data = {uid: 'abc123', email: 'user@example.com',};
+        const data = {uid: 'abc123', email: 'user@example.com'};
         mutations.setCurrentUser(state, data);
         expect(state.currentUser).toBe(data);
       });

--- a/hosting/qt/tests/unit/utils/sanitizeFirestore.spec.js
+++ b/hosting/qt/tests/unit/utils/sanitizeFirestore.spec.js
@@ -52,7 +52,7 @@ describe('utils/sanitizeFirestore', () => {
       },
       emails: [
         'jsmith@gmail.com',
-        'john.smith@outlook.com'
+        'john.smith@outlook.com',
       ],
       qt_passed: true,
       qt_score: 28,
@@ -68,7 +68,7 @@ describe('utils/sanitizeFirestore', () => {
     });
     expect(sanitized.emails).toEqual([
       'jsmith@gmail.com',
-      'john.smith@outlook.com'
+      'john.smith@outlook.com',
     ]);
     expect(sanitized.qt_passed).toEqual(true);
     expect(sanitized.qt_score).toEqual(28);

--- a/hosting/qt/tests/unit/views/TakeTest.spec.js
+++ b/hosting/qt/tests/unit/views/TakeTest.spec.js
@@ -13,7 +13,7 @@ const mockQt = {
     {
       title: 'Critical Analysis',
       form_url: 'https://qt.judicialappointments.digital/test/critical-analysis',
-    }
+    },
   ],
 };
 
@@ -111,9 +111,9 @@ describe.skip('views/TakeTest', () => {
   describe('template', () => {
     let loadingMessage, errorMessage, qtView;
     const findElements = () => {
-      loadingMessage = wrapper.find({ref: 'loadingMessage',});
-      errorMessage = wrapper.find({ref: 'errorMessage',});
-      qtView = wrapper.find({ref: 'qtView',});
+      loadingMessage = wrapper.find({ref: 'loadingMessage'});
+      errorMessage = wrapper.find({ref: 'errorMessage'});
+      qtView = wrapper.find({ref: 'qtView'});
     };
 
     describe('when the QT data hasn\'t loaded yet', () => {

--- a/hosting/reference/.eslintrc
+++ b/hosting/reference/.eslintrc
@@ -12,13 +12,11 @@
     "cypress"
   ],
   "rules": {
-    "comma-dangle": ["error", {
-      "objects": "always"
-    }],
-    "semi": "error",
+    "comma-dangle": ["error", {"arrays": "always-multiline", "objects": "always-multiline"}],
+    "eol-last": ["error", "always"],
     "func-style": ["error", "expression"],
     "prefer-arrow-callback": "error",
-    "quotes": ["error", "single", { "avoidEscape": true}],
-    "eol-last": ["error", "always"],
+    "quotes": ["error", "single", {"avoidEscape": true}],
+    "semi": "error"
   }
 }

--- a/hosting/reference/cypress/integration/content_spec.js
+++ b/hosting/reference/cypress/integration/content_spec.js
@@ -1,4 +1,4 @@
-/* eslint-disable */
+/* eslint-disable cypress/no-unnecessary-waiting */
 describe('Content', () => {
 
   beforeEach(() => {

--- a/hosting/reference/package.json
+++ b/hosting/reference/package.json
@@ -4,7 +4,7 @@
   "description": "A page allowing referees ('assessors') to upload their references ('independent assessments') to support a candidate's  application.",
   "main": "index.html",
   "scripts": {
-    "lint": "eslint 'Cypress/**'",
+    "lint": "eslint 'cypress/**'",
     "serve": "npx serve -n -l 8002 & wait-on http://localhost:8002",
     "cypress-ci": "npm run serve; cypress run --config video=false",
     "cypress-local": "npm run serve; cypress open; kill -9 $(lsof -ti tcp:8002)",


### PR DESCRIPTION
This PR updates the `eslint` configuration to use rules recommended by the Vue project. The reason behind this change is to introduce a more opinionated set of linter rules which will help us to better define and enforce a house style. This is more important now that our development team is growing, so multiple developers will be working across the codebase.

### Configuration changes

Out of the box, the Vue CLI configures projects to use the rule set:
[Priority A: Essential (Error Prevention)](https://eslint.vuejs.org/rules/#priority-a-essential-error-prevention)

I've updated the configuration to use the more opinionated rule set:
[Priority C: Recommended (Minimizing Arbitrary Choices and Cognitive Overhead)](https://eslint.vuejs.org/rules/#priority-c-recommended-minimizing-arbitrary-choices-and-cognitive-overhead)

In addition to the recommended Vue rules, I've also adjusted the `comma-dangle` rule so that it only applies to multi-line objects and arrays. Previously this applied to single-line objects, which as a dev team we agreed was ugly and seemed unnecessary.

### Code changes

All code changes in this PR are purely for compliance with the new linter rules.

Most changes were made automatically by `eslint`, which runs in 'auto-fix' mode by default when run in a Vue project:

```
npm run lint
```

It wasn't possible to automatically fix every linter warning, so some of these changes were made manually.

### No changes to Cloud Functions

This PR **does not** change code style for anything in the `/functions` directory. This is done in a separate PR: #197 