### PR TITLE
Make lint and CI behaviour more predictable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           at: ~/digital-platform
       - run:
           name: 'Lint hosting/apply'
-          command: npm --prefix hosting/apply run lint
+          command: npm --prefix hosting/apply run lint-ci
       - run:
           name: 'Test hosting/apply'
           command: npm --prefix hosting/apply run test-ci
@@ -88,7 +88,7 @@ jobs:
           command: git rebase master
       - run:
           name: 'Lint hosting/apply'
-          command: npm --prefix hosting/apply run lint
+          command: npm --prefix hosting/apply run lint-ci
       - run:
           name: 'Test hosting/apply'
           command: npm --prefix hosting/apply run test-ci
@@ -100,7 +100,7 @@ jobs:
           at: ~/digital-platform
       - run:
           name: 'Lint hosting/qt'
-          command: npm --prefix hosting/qt run lint
+          command: npm --prefix hosting/qt run lint-ci
       - run:
           name: 'Test hosting/qt'
           command: npm --prefix hosting/qt run test-ci
@@ -115,7 +115,7 @@ jobs:
           command: git rebase master
       - run:
           name: 'Lint hosting/qt'
-          command: npm --prefix hosting/qt run lint
+          command: npm --prefix hosting/qt run lint-ci
       - run:
           name: 'Test hosting/qt'
           command: npm --prefix hosting/qt run test-ci
@@ -127,7 +127,7 @@ jobs:
           at: ~/digital-platform
       - run:
           name: 'Lint hosting/qt-admin'
-          command: npm --prefix hosting/qt-admin run lint
+          command: npm --prefix hosting/qt-admin run lint-ci
       - run:
           name: 'Test hosting/qt-admin'
           command: npm --prefix hosting/qt-admin run test-ci
@@ -142,7 +142,7 @@ jobs:
           command: git rebase master
       - run:
           name: 'Lint hosting/qt-admin'
-          command: npm --prefix hosting/qt-admin run lint
+          command: npm --prefix hosting/qt-admin run lint-ci
       - run:
           name: 'Test hosting/qt-admin'
           command: npm --prefix hosting/qt-admin run test-ci
@@ -167,6 +167,9 @@ jobs:
             libxtst6 \
             xauth \
             xvfb
+      - run:
+          name: 'Lint hosting/reference'
+          command: npm --prefix hosting/reference run lint-ci
       - run:
           name: 'Test hosting/reference'
           command: |
@@ -196,6 +199,9 @@ jobs:
             libxtst6 \
             xauth \
             xvfb
+      - run:
+          name: 'Lint hosting/reference'
+          command: npm --prefix hosting/reference run lint-ci
       - run:
           name: 'Test hosting/reference'
           command: |

--- a/hosting/apply/package.json
+++ b/hosting/apply/package.json
@@ -6,6 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
+    "lint-ci": "vue-cli-service lint --no-fix",
     "test": "TZ='Europe/London' vue-cli-service test:unit",
     "test-ci": "TZ='Europe/London' vue-cli-service test:unit --ci --runInBand"
   },

--- a/hosting/qt-admin/package.json
+++ b/hosting/qt-admin/package.json
@@ -6,6 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
+    "lint-ci": "vue-cli-service lint --no-fix",
     "test": "vue-cli-service test:unit",
     "test-ci": "vue-cli-service test:unit"
   },

--- a/hosting/qt/package.json
+++ b/hosting/qt/package.json
@@ -6,6 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
+    "lint-ci": "vue-cli-service lint --no-fix",
     "test": "vue-cli-service test:unit",
     "test-ci": "vue-cli-service test:unit --ci --runInBand"
   },

--- a/hosting/reference/package.json
+++ b/hosting/reference/package.json
@@ -4,7 +4,8 @@
   "description": "A page allowing referees ('assessors') to upload their references ('independent assessments') to support a candidate's  application.",
   "main": "index.html",
   "scripts": {
-    "lint": "eslint 'cypress/**'",
+    "lint": "eslint 'cypress/**' --fix",
+    "lint-ci": "eslint 'cypress/**'",
     "serve": "npx serve -n -l 8002 & wait-on http://localhost:8002",
     "cypress-ci": "npm run serve; cypress run --config video=false",
     "cypress-local": "npm run serve; cypress open; kill -9 $(lsof -ti tcp:8002)",


### PR DESCRIPTION
I've made linter commands more consistent between projects. By default, running `npm run lint` in a Vue project will run `eslint` with the `--fix` flag enabled. This means linter errors will be automatically and silently fixed where possible.

In contrast, in the non-Vue directory `hosting/references`, running `npm run lint` wouldn't automatically fix errors, because `eslint` was running without the `--fix` flag.

I've changed the behaviour of the `lint` command in `hosting/references` to be consistent with the Vue apps. Errors will now be auto-fixed.

Additionally, we don't want our CI server to ever attempt to automatically fix linter errors. Therefore I've added an additional command called `lint-ci` to each of the project `package.json` files. These commands will run the linter in read-only mode where it won't attempt to fix errors.

I've reconfigured CircleCI to use the `lint-ci` commands rather than `lint`, so that the linter fails when there are linter errors (rather than silently fixing and passing).