### PR TITLE
Apply admin deploy

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -17,6 +17,9 @@
         ],
         "qt-admin": [
           "jac-qt-admin"
+        ],
+        "apply-admin": [
+          "jac-apply-admin"
         ]
       }
     },
@@ -24,6 +27,9 @@
       "hosting": {
         "apply": [
           "jac-apply-staging"
+        ],
+        "apply-admin": [
+          "jac-apply-admin-staging"
         ],
         "reference": [
           "jac-reference-staging"

--- a/firebase.json
+++ b/firebase.json
@@ -21,6 +21,22 @@
       ]
     },
     {
+      "target": "apply-admin",
+      "predeploy": "npm --prefix hosting/apply-admin run build",
+      "public": "hosting/apply-admin/dist",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
+    },
+    {
       "target": "reference",
       "public": "hosting/reference",
       "ignore": [


### PR DESCRIPTION
This PR completes Trello card [#13 Configure the Digital Platform repo to deploy `apply-admin`](https://trello.com/c/XQMU8BmU/13-configure-the-digital-platform-repo-to-deploy-apply-admin)

It allows manual deployment of the `apply-admin` app to the `staging` and `production` environments`.
