### PR TITLE
Move init to onAuthStateChanged and check for isSignedIn value

### DIFF
--- a/hosting/apply-admin/src/main.js
+++ b/hosting/apply-admin/src/main.js
@@ -6,10 +6,11 @@ import { auth } from '@/firebase';
 Vue.config.productionTip = false;
 
 let vueInstance = false;
-auth().onAuthStateChanged((user) => {
+auth().onAuthStateChanged( (user) => {
   // Bind Firebase auth state to the vuex auth state store
   store.dispatch('setCurrentUser', user);
-
+  // Get vacancies from Firebase
+  store.dispatch('init');
   // Create the Vue instance, but only once
   if (!vueInstance) {
     vueInstance = new Vue({

--- a/hosting/apply-admin/src/store.js
+++ b/hosting/apply-admin/src/store.js
@@ -20,14 +20,14 @@ const store = new Vuex.Store({
   },
   actions: {
     init: async ({ dispatch }) => {
-      await Promise.all([
-        dispatch('vacancies/bind'),
-      ]);
+      if(store.getters.isSignedIn) {
+        await Promise.all([
+          dispatch('vacancies/bind'),
+        ]);
+      }
     },
   },
   getters: {},
 });
-
-store.dispatch('init');
 
 export default store;

--- a/hosting/apply-admin/tests/unit/store/store.spec.js
+++ b/hosting/apply-admin/tests/unit/store/store.spec.js
@@ -27,7 +27,7 @@ describe('Vuex store', () => {
       expect(dispatch).toHaveBeenCalled();
     });
 
-     it('not calling dispatch if user is not signed in', () => {
+     it('does not call dispatch if user is not signed in', () => {
       store.getters.isSignedIn = false;
       const dispatch = jest.fn().mockResolvedValue();
       store.actions.init({ dispatch });

--- a/hosting/apply-admin/tests/unit/store/store.spec.js
+++ b/hosting/apply-admin/tests/unit/store/store.spec.js
@@ -1,0 +1,38 @@
+import store from '@/store';
+import Vuex from 'vuex';
+
+jest.mock('vuex', () => {
+  return {
+    Store: jest.fn((config) => {
+      return config;
+    }),
+  };
+});
+
+describe('Vuex store', () => {
+  it('has strict mode enabled', () => {
+    expect(store.strict).toBe(true);
+  });
+
+  it('creates a new Vuex Store', () => {
+    expect(Vuex.Store).toHaveBeenCalled();
+  });
+
+  describe('init action', () => {
+    it('calls dispatch if user is signed in', () => {
+      store.getters.isSignedIn = true;
+      const dispatch = jest.fn().mockResolvedValue();
+      store.actions.init({ dispatch });
+
+      expect(dispatch).toHaveBeenCalled();
+    });
+
+     it('not calling dispatch if user is not signed in', () => {
+      store.getters.isSignedIn = false;
+      const dispatch = jest.fn().mockResolvedValue();
+      store.actions.init({ dispatch });
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
As we don't want to bind vacancies if a user is not logged in, init is moved to onAuthStateChanged method. Also, added a check for isSignedIn status and tests.

**Change log:**
1) Move "init" to main.js into an onAuthStateChanged method
2) In init action before dispatching 'vacancies/bind' we check for user status