### PR TITLE
Rename vacancies collection to exercise

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -27,7 +27,7 @@ service cloud.firestore {
                        resource.data.state != "submitted";
     }
 
-    match /vacancies/{vacancy} {
+    match /exercises/{exercise} {
       // Authenticated users can read
       allow get, list, write: if userIsAuthenticated();
     }


### PR DESCRIPTION
**Change log:**

Rename `vacancies` collection to `exercises` as this is the term we use internally at JAC.