### PR TITLE
Add created at attribute on exercise create

### DIFF
--- a/functions/exercises/handleExerciseMailboxChange.js
+++ b/functions/exercises/handleExerciseMailboxChange.js
@@ -24,11 +24,11 @@ exports.handleExerciseMailboxChange = functions.firestore
       // More info here:
       // https://firebase.google.com/docs/firestore/manage-data/add-data#set_a_document
       const setWithMerge = exerciseRef.set({
-        exerciseMailbox: previousEmail 
+        exerciseMailbox: previousEmail, 
       }, { merge: true});
 
-      console.error(`${email} is an invalid email format. Leaving email mailbox as ${previousEmail}`)
-      return null;      
+      console.error(`${email} is an invalid email format. Leaving email mailbox as ${previousEmail}`);
+      return null;
     }
 
     // We'll only update if the exerciseMailbox has changed.
@@ -40,7 +40,7 @@ exports.handleExerciseMailboxChange = functions.firestore
       exerciseName: data.name,
       previousEmail: previousEmail,
       newEmail: email,
-    }
+    };
 
     // Check that the firebase config has the key by running:
     // firebase functions:config:get

--- a/functions/exercises/handleExerciseMailboxChange.js
+++ b/functions/exercises/handleExerciseMailboxChange.js
@@ -5,7 +5,7 @@ const emailIsValid = require('../sharedServices').emailIsValid;
 const db = require('../sharedServices').db;
 
 exports.handleExerciseMailboxChange = functions.firestore
-  .document('users/{userId}')
+  .document('exercises/{exerciseId}')
   .onUpdate((change, context) => {
 
     // Retrieve the current and previous value
@@ -54,4 +54,3 @@ exports.handleExerciseMailboxChange = functions.firestore
       return true;
     });
   });
-

--- a/functions/exercises/handleExerciseMailboxChange.js
+++ b/functions/exercises/handleExerciseMailboxChange.js
@@ -1,0 +1,57 @@
+/*eslint-disable no-unused-vars*/
+const functions = require('firebase-functions');
+const sendEmail = require('../sharedServices').sendEmail;
+const emailIsValid = require('../sharedServices').emailIsValid;
+const db = require('../sharedServices').db;
+
+exports.handleExerciseMailboxChange = functions.firestore
+  .document('users/{userId}')
+  .onUpdate((change, context) => {
+
+    // Retrieve the current and previous value
+    const data = change.after.data();
+    const previousData = change.before.data();
+
+    const email = data.exerciseMailbox;
+    const previousEmail = previousData.exerciseMailbox;
+
+    if (emailIsValid(email) == false) {
+      // Make sure to set the email back to the previous email
+      // when email address is invalid
+      const exerciseRef = db.collection('exercises').doc(context.params.exerciseId);
+
+      // You need the "merge: true" part, or else it might overwrite an already existing document.
+      // More info here:
+      // https://firebase.google.com/docs/firestore/manage-data/add-data#set_a_document
+      const setWithMerge = exerciseRef.set({
+        exerciseMailbox: previousEmail 
+      }, { merge: true});
+
+      console.error(`${email} is an invalid email format. Leaving email mailbox as ${previousEmail}`)
+      return null;      
+    }
+
+    // We'll only update if the exerciseMailbox has changed.
+    // This is crucial to prevent infinite loops.
+    if (email == previousEmail) return null;
+
+    // set this data to personalize the Exercise mailbox changed email template
+    const personalizationData = {
+      exerciseName: data.name,
+      previousEmail: previousEmail,
+      newEmail: email,
+    }
+
+    // Check that the firebase config has the key by running:
+    // firebase functions:config:get
+    //
+    // Set notify.templates.exercise_mailbox_changed in firebase functions like this:
+    // firebase functions:config:set notify.templates.exercise_mailbox_changed="THE_GOVUK_NOTIFY_TEMPLATE_ID"
+    const templateId = functions.config().notify.templates.exercise_mailbox_changed;
+
+    return sendEmail(email, templateId, personalizationData).then((sendEmailResponse) => {
+      console.info(`Exercise "${data.name}" - mailbox ${previousEmail} has been changed to ${email}`);
+      return true;
+    });
+  });
+

--- a/functions/exercises/sendExerciseStartedEmail.js
+++ b/functions/exercises/sendExerciseStartedEmail.js
@@ -1,15 +1,23 @@
 /*eslint-disable no-unused-vars*/
 const functions = require('firebase-functions');
 const sendEmail = require('../sharedServices').sendEmail;
+const db = require('../sharedServices').db;
 
-const sendExerciseStartedEmail = async (snap, context) => {
+exports.sendExerciseStartedEmail = functions.firestore
+  .document('exercises/{exerciseId}')
+  .onCreate( (snap, context) => {
     const data = snap.data();
     const email = data.exerciseMailbox;
+
+    // set createdAt attribute here instead of receiving it from the Vue apply app 
+    const exerciseRef = db.collection('exercises').doc(context.params.exerciseId);
+    const setWithMerge = exerciseRef.set({
+      createdAt: Date.now(), 
+    }, { merge: true});
+
     const templateId = functions.config().notify.templates.exercise_started;
     return sendEmail(email, templateId, {}).then((sendEmailResponse) => {
       console.info(email + ' has created an Exercise.');
       return true;
     });
-  };
-
-module.exports = sendExerciseStartedEmail;
+  });

--- a/functions/index.js
+++ b/functions/index.js
@@ -14,6 +14,7 @@ exports.backupFirestore = require('./backup/firestore');
 const sendEmail = require('./sharedServices').sendEmail;
 
 exports.sendExerciseStartedEmail = require('./exercises/sendExerciseStartedEmail');
+exports.handleExerciseMailboxChange = require('./exercises/handleExerciseMailboxChange');
 
 /*
  *  TODO: All functions below this comment should be refactored into separate files.

--- a/functions/index.js
+++ b/functions/index.js
@@ -13,11 +13,7 @@ exports.backupFirestore = require('./backup/firestore');
 
 const sendEmail = require('./sharedServices').sendEmail;
 
-const sendExerciseStartedEmail = require('./exercises/sendExerciseStartedEmail');
-
-module.exports = {
-  'sendExerciseStartedEmail': functions.firestore.document('exercises/{exerciseId}').onCreate(sendExerciseStartedEmail),
-};
+exports.sendExerciseStartedEmail = require('./exercises/sendExerciseStartedEmail');
 
 /*
  *  TODO: All functions below this comment should be refactored into separate files.

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -964,14 +964,6 @@
       "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
       "dev": true
     },
-    "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-      "requires": {
-        "es6-promisify": "^5.0.0"
-      }
-    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -4878,9 +4870,9 @@
       }
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5053,14 +5045,22 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -5068,11 +5068,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -7360,9 +7355,9 @@
       }
     },
     "npm": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.10.1.tgz",
-      "integrity": "sha512-ejR83c5aPTip5hPhziypqkJu06vb5tDIugCXx1c5+04RbMjtZeMA6BfsuGnV9EBdEwzKoaHkQ9sJWQAq+LjHYw==",
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.13.1.tgz",
+      "integrity": "sha512-2awiDZ9JuV/UoF4oXGhekCURC2X+eLLRz9/e58AGrPDlpzyn7e4oCaZmkzyEaisxM7jSoFKNnZhzB4xbmbM0Yw==",
       "requires": {
         "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
@@ -7370,16 +7365,16 @@
         "ansistyles": "~0.1.3",
         "aproba": "^2.0.0",
         "archy": "~1.0.0",
-        "bin-links": "^1.1.2",
+        "bin-links": "^1.1.3",
         "bluebird": "^3.5.5",
         "byte-size": "^5.0.1",
-        "cacache": "^11.3.3",
+        "cacache": "^12.0.3",
         "call-limit": "^1.1.1",
-        "chownr": "^1.1.2",
+        "chownr": "^1.1.3",
         "ci-info": "^2.0.0",
         "cli-columns": "^3.1.2",
         "cli-table3": "^0.5.1",
-        "cmd-shim": "~2.0.2",
+        "cmd-shim": "^3.0.3",
         "columnify": "~1.5.4",
         "config-chain": "^1.1.12",
         "debuglog": "*",
@@ -7391,13 +7386,14 @@
         "find-npm-prefix": "^1.0.2",
         "fs-vacuum": "~1.2.10",
         "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.0.1",
+        "gentle-fs": "^2.2.1",
         "glob": "^7.1.4",
-        "graceful-fs": "^4.2.0",
+        "graceful-fs": "^4.2.3",
         "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.7.1",
+        "hosted-git-info": "^2.8.5",
         "iferr": "^1.0.2",
         "imurmurhash": "*",
+        "infer-owner": "^1.0.4",
         "inflight": "~1.0.6",
         "inherits": "^2.0.4",
         "ini": "^1.3.5",
@@ -7405,13 +7401,13 @@
         "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
         "lazy-property": "~1.0.0",
-        "libcipm": "^4.0.0",
-        "libnpm": "^3.0.0",
-        "libnpmaccess": "*",
-        "libnpmhook": "^5.0.2",
-        "libnpmorg": "*",
-        "libnpmsearch": "^2.0.1",
-        "libnpmteam": "*",
+        "libcipm": "^4.0.7",
+        "libnpm": "^3.0.1",
+        "libnpmaccess": "^3.0.2",
+        "libnpmhook": "^5.0.3",
+        "libnpmorg": "^1.0.1",
+        "libnpmsearch": "^2.0.2",
+        "libnpmteam": "^1.0.2",
         "libnpx": "^10.2.0",
         "lock-verify": "^2.1.0",
         "lockfile": "^1.0.4",
@@ -7431,33 +7427,33 @@
         "mississippi": "^3.0.0",
         "mkdirp": "~0.5.1",
         "move-concurrently": "^1.0.1",
-        "node-gyp": "^5.0.2",
+        "node-gyp": "^5.0.5",
         "nopt": "~4.0.1",
         "normalize-package-data": "^2.5.0",
         "npm-audit-report": "^1.3.2",
         "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "^3.0.0",
-        "npm-package-arg": "^6.1.0",
-        "npm-packlist": "^1.4.4",
-        "npm-pick-manifest": "^2.2.3",
-        "npm-profile": "*",
-        "npm-registry-fetch": "^3.9.1",
+        "npm-install-checks": "^3.0.2",
+        "npm-lifecycle": "^3.1.4",
+        "npm-package-arg": "^6.1.1",
+        "npm-packlist": "^1.4.6",
+        "npm-pick-manifest": "^3.0.2",
+        "npm-profile": "^4.0.2",
+        "npm-registry-fetch": "^4.0.2",
         "npm-user-validate": "~1.0.0",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
         "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^9.5.1",
+        "pacote": "^9.5.9",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.8.1",
+        "query-string": "^6.8.2",
         "qw": "~1.0.1",
         "read": "~1.0.7",
-        "read-cmd-shim": "~1.0.1",
+        "read-cmd-shim": "^1.0.5",
         "read-installed": "~4.0.3",
-        "read-package-json": "^2.0.13",
+        "read-package-json": "^2.1.0",
         "read-package-tree": "^5.3.1",
         "readable-stream": "^3.4.0",
         "readdir-scoped-modules": "^1.1.0",
@@ -7465,14 +7461,14 @@
         "retry": "^0.12.0",
         "rimraf": "^2.6.3",
         "safe-buffer": "^5.1.2",
-        "semver": "^5.7.0",
+        "semver": "^5.7.1",
         "sha": "^3.0.0",
         "slide": "~1.1.6",
         "sorted-object": "~2.0.1",
         "sorted-union-stream": "~2.1.3",
         "ssri": "^6.0.1",
-        "stringify-package": "^1.0.0",
-        "tar": "^4.4.10",
+        "stringify-package": "^1.0.1",
+        "tar": "^4.4.13",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
@@ -7480,7 +7476,7 @@
         "unique-filename": "^1.1.1",
         "unpipe": "~1.0.0",
         "update-notifier": "^2.5.0",
-        "uuid": "^3.3.2",
+        "uuid": "^3.3.3",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "~3.0.0",
         "which": "^1.3.1",
@@ -7501,14 +7497,14 @@
           "bundled": true
         },
         "agent-base": {
-          "version": "4.2.1",
+          "version": "4.3.0",
           "bundled": true,
           "requires": {
             "es6-promisify": "^5.0.0"
           }
         },
         "agentkeepalive": {
-          "version": "3.4.1",
+          "version": "3.5.2",
           "bundled": true,
           "requires": {
             "humanize-ms": "^1.2.1"
@@ -7628,13 +7624,13 @@
           }
         },
         "bin-links": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.0",
-            "cmd-shim": "^2.0.2",
-            "gentle-fs": "^2.0.0",
-            "graceful-fs": "^4.1.11",
+            "bluebird": "^3.5.3",
+            "cmd-shim": "^3.0.0",
+            "gentle-fs": "^2.0.1",
+            "graceful-fs": "^4.1.15",
             "write-file-atomic": "^2.3.0"
           }
         },
@@ -7680,7 +7676,7 @@
           "bundled": true
         },
         "cacache": {
-          "version": "11.3.3",
+          "version": "12.0.3",
           "bundled": true,
           "requires": {
             "bluebird": "^3.5.5",
@@ -7688,6 +7684,7 @@
             "figgy-pudding": "^3.5.1",
             "glob": "^7.1.4",
             "graceful-fs": "^4.1.15",
+            "infer-owner": "^1.0.3",
             "lru-cache": "^5.1.1",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
@@ -7697,20 +7694,6 @@
             "ssri": "^6.0.1",
             "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.4",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            }
           }
         },
         "call-limit": {
@@ -7739,7 +7722,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true
         },
         "ci-info": {
@@ -7801,7 +7784,7 @@
           "bundled": true
         },
         "cmd-shim": {
-          "version": "2.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -8155,7 +8138,7 @@
           }
         },
         "es6-promise": {
-          "version": "4.2.6",
+          "version": "4.2.8",
           "bundled": true
         },
         "es6-promisify": {
@@ -8293,10 +8276,20 @@
           }
         },
         "fs-minipass": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
           }
         },
         "fs-vacuum": {
@@ -8386,13 +8379,15 @@
           "bundled": true
         },
         "gentle-fs": {
-          "version": "2.0.1",
+          "version": "2.2.1",
           "bundled": true,
           "requires": {
             "aproba": "^1.1.2",
+            "chownr": "^1.1.2",
             "fs-vacuum": "^1.2.10",
             "graceful-fs": "^4.1.11",
             "iferr": "^0.1.5",
+            "infer-owner": "^1.0.4",
             "mkdirp": "^0.5.1",
             "path-is-inside": "^1.0.2",
             "read-cmd-shim": "^1.0.1",
@@ -8470,7 +8465,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.0",
+          "version": "4.2.3",
           "bundled": true
         },
         "har-schema": {
@@ -8505,7 +8500,7 @@
           "bundled": true
         },
         "hosted-git-info": {
-          "version": "2.7.1",
+          "version": "2.8.5",
           "bundled": true
         },
         "http-cache-semantics": {
@@ -8530,10 +8525,10 @@
           }
         },
         "https-proxy-agent": {
-          "version": "2.2.1",
+          "version": "2.2.4",
           "bundled": true,
           "requires": {
-            "agent-base": "^4.1.0",
+            "agent-base": "^4.3.0",
             "debug": "^3.1.0"
           }
         },
@@ -8556,7 +8551,7 @@
           "bundled": true
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -8568,6 +8563,10 @@
         },
         "imurmurhash": {
           "version": "0.1.4",
+          "bundled": true
+        },
+        "infer-owner": {
+          "version": "1.0.4",
           "bundled": true
         },
         "inflight": {
@@ -8766,7 +8765,7 @@
           }
         },
         "libcipm": {
-          "version": "4.0.0",
+          "version": "4.0.7",
           "bundled": true,
           "requires": {
             "bin-links": "^1.1.2",
@@ -8787,45 +8786,39 @@
           }
         },
         "libnpm": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.3",
             "find-npm-prefix": "^1.0.2",
-            "libnpmaccess": "^3.0.1",
+            "libnpmaccess": "^3.0.2",
             "libnpmconfig": "^1.2.1",
-            "libnpmhook": "^5.0.2",
-            "libnpmorg": "^1.0.0",
-            "libnpmpublish": "^1.1.0",
-            "libnpmsearch": "^2.0.0",
-            "libnpmteam": "^1.0.1",
+            "libnpmhook": "^5.0.3",
+            "libnpmorg": "^1.0.1",
+            "libnpmpublish": "^1.1.2",
+            "libnpmsearch": "^2.0.2",
+            "libnpmteam": "^1.0.2",
             "lock-verify": "^2.0.2",
             "npm-lifecycle": "^3.0.0",
             "npm-logical-tree": "^1.2.1",
             "npm-package-arg": "^6.1.0",
-            "npm-profile": "^4.0.1",
-            "npm-registry-fetch": "^3.8.0",
+            "npm-profile": "^4.0.2",
+            "npm-registry-fetch": "^4.0.0",
             "npmlog": "^4.1.2",
-            "pacote": "^9.2.3",
+            "pacote": "^9.5.3",
             "read-package-json": "^2.0.13",
             "stringify-package": "^1.0.0"
           }
         },
         "libnpmaccess": {
-          "version": "3.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
             "get-stream": "^4.0.0",
             "npm-package-arg": "^6.1.0",
-            "npm-registry-fetch": "^3.8.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "2.0.0",
-              "bundled": true
-            }
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmconfig": {
@@ -8873,33 +8866,27 @@
           }
         },
         "libnpmhook": {
-          "version": "5.0.2",
+          "version": "5.0.3",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
             "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^3.8.0"
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmorg": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
             "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^3.8.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "2.0.0",
-              "bundled": true
-            }
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmpublish": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -8908,34 +8895,28 @@
             "lodash.clonedeep": "^4.5.0",
             "normalize-package-data": "^2.4.0",
             "npm-package-arg": "^6.1.0",
-            "npm-registry-fetch": "^3.8.0",
+            "npm-registry-fetch": "^4.0.0",
             "semver": "^5.5.1",
             "ssri": "^6.0.1"
           }
         },
         "libnpmsearch": {
-          "version": "2.0.1",
+          "version": "2.0.2",
           "bundled": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
             "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^3.8.0"
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmteam": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
             "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^3.8.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "2.0.0",
-              "bundled": true
-            }
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpx": {
@@ -9053,14 +9034,14 @@
           }
         },
         "make-fetch-happen": {
-          "version": "4.0.2",
+          "version": "5.0.2",
           "bundled": true,
           "requires": {
             "agentkeepalive": "^3.4.1",
-            "cacache": "^11.3.3",
+            "cacache": "^12.0.0",
             "http-cache-semantics": "^3.8.1",
             "http-proxy-agent": "^2.1.0",
-            "https-proxy-agent": "^2.2.1",
+            "https-proxy-agent": "^2.2.3",
             "lru-cache": "^5.1.1",
             "mississippi": "^3.0.0",
             "node-fetch-npm": "^2.0.2",
@@ -9106,25 +9087,21 @@
           "version": "0.0.8",
           "bundled": true
         },
-        "minipass": {
-          "version": "2.3.3",
+        "minizlib": {
+          "version": "1.3.3",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "minipass": "^2.9.0"
           },
           "dependencies": {
-            "yallist": {
-              "version": "3.0.2",
-              "bundled": true
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
             }
-          }
-        },
-        "minizlib": {
-          "version": "1.2.1",
-          "bundled": true,
-          "requires": {
-            "minipass": "^2.2.1"
           }
         },
         "mississippi": {
@@ -9186,7 +9163,7 @@
           }
         },
         "node-gyp": {
-          "version": "5.0.2",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
             "env-paths": "^1.0.0",
@@ -9198,7 +9175,7 @@
             "request": "^2.87.0",
             "rimraf": "2",
             "semver": "~5.3.0",
-            "tar": "^4.4.8",
+            "tar": "^4.4.12",
             "which": "1"
           },
           "dependencies": {
@@ -9259,14 +9236,14 @@
           "bundled": true
         },
         "npm-install-checks": {
-          "version": "3.0.0",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
             "semver": "^2.3.0 || 3.x || 4 || 5"
           }
         },
         "npm-lifecycle": {
-          "version": "3.0.0",
+          "version": "3.1.4",
           "bundled": true,
           "requires": {
             "byline": "^5.0.0",
@@ -9284,17 +9261,17 @@
           "bundled": true
         },
         "npm-package-arg": {
-          "version": "6.1.0",
+          "version": "6.1.1",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^2.6.0",
+            "hosted-git-info": "^2.7.1",
             "osenv": "^0.1.5",
-            "semver": "^5.5.0",
+            "semver": "^5.6.0",
             "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
-          "version": "1.4.4",
+          "version": "1.4.6",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -9302,7 +9279,7 @@
           }
         },
         "npm-pick-manifest": {
-          "version": "2.2.3",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
@@ -9311,42 +9288,30 @@
           }
         },
         "npm-profile": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "bundled": true,
           "requires": {
             "aproba": "^1.1.2 || 2",
             "figgy-pudding": "^3.4.1",
-            "npm-registry-fetch": "^3.8.0"
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "3.9.1",
+          "version": "4.0.2",
           "bundled": true,
           "requires": {
             "JSONStream": "^1.3.4",
             "bluebird": "^3.5.1",
             "figgy-pudding": "^3.4.1",
             "lru-cache": "^5.1.1",
-            "make-fetch-happen": "^4.0.2",
-            "npm-package-arg": "^6.1.0"
+            "make-fetch-happen": "^5.0.0",
+            "npm-package-arg": "^6.1.0",
+            "safe-buffer": "^5.2.0"
           },
           "dependencies": {
-            "make-fetch-happen": {
-              "version": "4.0.2",
-              "bundled": true,
-              "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^11.3.3",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.1",
-                "lru-cache": "^5.1.1",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^4.0.0",
-                "ssri": "^6.0.0"
-              }
+            "safe-buffer": {
+              "version": "5.2.0",
+              "bundled": true
             }
           }
         },
@@ -9464,16 +9429,18 @@
           }
         },
         "pacote": {
-          "version": "9.5.1",
+          "version": "9.5.9",
           "bundled": true,
           "requires": {
             "bluebird": "^3.5.3",
-            "cacache": "^11.3.2",
+            "cacache": "^12.0.2",
+            "chownr": "^1.1.2",
             "figgy-pudding": "^3.5.1",
             "get-stream": "^4.1.0",
             "glob": "^7.1.3",
+            "infer-owner": "^1.0.4",
             "lru-cache": "^5.1.1",
-            "make-fetch-happen": "^4.0.1",
+            "make-fetch-happen": "^5.0.0",
             "minimatch": "^3.0.4",
             "minipass": "^2.3.5",
             "mississippi": "^3.0.0",
@@ -9481,8 +9448,8 @@
             "normalize-package-data": "^2.4.0",
             "npm-package-arg": "^6.1.0",
             "npm-packlist": "^1.1.12",
-            "npm-pick-manifest": "^2.2.3",
-            "npm-registry-fetch": "^3.8.0",
+            "npm-pick-manifest": "^3.0.0",
+            "npm-registry-fetch": "^4.0.0",
             "osenv": "^0.1.5",
             "promise-inflight": "^1.0.1",
             "promise-retry": "^1.1.1",
@@ -9491,13 +9458,13 @@
             "safe-buffer": "^5.1.2",
             "semver": "^5.6.0",
             "ssri": "^6.0.1",
-            "tar": "^4.4.8",
+            "tar": "^4.4.10",
             "unique-filename": "^1.1.1",
             "which": "^1.3.1"
           },
           "dependencies": {
             "minipass": {
-              "version": "2.3.5",
+              "version": "2.9.0",
               "bundled": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -9661,7 +9628,7 @@
           "bundled": true
         },
         "query-string": {
-          "version": "6.8.1",
+          "version": "6.8.2",
           "bundled": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
@@ -9697,7 +9664,7 @@
           }
         },
         "read-cmd-shim": {
-          "version": "1.0.1",
+          "version": "1.0.5",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.2"
@@ -9717,7 +9684,7 @@
           }
         },
         "read-package-json": {
-          "version": "2.0.13",
+          "version": "2.1.0",
           "bundled": true,
           "requires": {
             "glob": "^7.1.1",
@@ -9841,7 +9808,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true
         },
         "semver-diff": {
@@ -9886,23 +9853,32 @@
           "bundled": true
         },
         "smart-buffer": {
-          "version": "4.0.1",
+          "version": "4.1.0",
           "bundled": true
         },
         "socks": {
-          "version": "2.2.0",
+          "version": "2.3.3",
           "bundled": true,
           "requires": {
-            "ip": "^1.1.5",
-            "smart-buffer": "^4.0.1"
+            "ip": "1.1.5",
+            "smart-buffer": "^4.1.0"
           }
         },
         "socks-proxy-agent": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "bundled": true,
           "requires": {
-            "agent-base": "~4.2.0",
-            "socks": "~2.2.0"
+            "agent-base": "~4.2.1",
+            "socks": "~2.3.2"
+          },
+          "dependencies": {
+            "agent-base": {
+              "version": "4.2.1",
+              "bundled": true,
+              "requires": {
+                "es6-promisify": "^5.0.0"
+              }
+            }
           }
         },
         "sorted-object": {
@@ -10074,7 +10050,7 @@
           }
         },
         "stringify-package": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true
         },
         "strip-ansi": {
@@ -10100,12 +10076,12 @@
           }
         },
         "tar": {
-          "version": "4.4.10",
+          "version": "4.4.13",
           "bundled": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.5",
+            "minipass": "^2.8.6",
             "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
@@ -10113,16 +10089,12 @@
           },
           "dependencies": {
             "minipass": {
-              "version": "2.3.5",
+              "version": "2.9.0",
               "bundled": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
               }
-            },
-            "yallist": {
-              "version": "3.0.3",
-              "bundled": true
             }
           }
         },
@@ -10279,7 +10251,7 @@
           }
         },
         "uuid": {
-          "version": "3.3.2",
+          "version": "3.3.3",
           "bundled": true
         },
         "validate-npm-package-license": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -25,7 +25,7 @@
     "googleapis": "^43.0.0",
     "install": "^0.12.2",
     "notifications-node-client": "^4.6.0",
-    "npm": "^6.10.1",
+    "npm": "^6.13.1",
     "request": "^2.88.0"
   },
   "devDependencies": {

--- a/functions/sharedServices.js
+++ b/functions/sharedServices.js
@@ -30,7 +30,12 @@ const sendEmail = (email, templateId, personalisation) => {
     });
 };
 
+const emailIsValid = (email) => {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+};
+
 module.exports = {
   db,
   sendEmail,
+  emailIsValid,
 };

--- a/functions/sharedServices.js
+++ b/functions/sharedServices.js
@@ -31,7 +31,7 @@ const sendEmail = (email, templateId, personalisation) => {
 };
 
 const emailIsValid = (email) => {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 };
 
 module.exports = {


### PR DESCRIPTION
This includes refactoring of index.js, as we want to encourage making new cloud functions in separate files.

The main change here is that before, we were adding the 'createdAt' field to the Exercise document via supplying the 'createdAt' field in the 'apply-admin' Vue app. Now we add 'createdAt' field when the Exercise document onCreate method is triggered.