### PR TITLE
Handle candidate on create

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,6 +9,12 @@ service cloud.firestore {
       allow get, create, update: if request.auth.uid == userId;
     }
 
+    match /meta/stats {
+      // allow any authenticated user to read & write meta
+      // @todo restrict this to admin
+      allow read, write: if userIsAuthenticated();
+    }
+
     match /applications/{application} {
       function currentUser() {
         return request.auth.uid;

--- a/functions/candidates/handleCandidateOnCreate.js
+++ b/functions/candidates/handleCandidateOnCreate.js
@@ -1,0 +1,35 @@
+/*eslint-disable no-unused-vars*/
+const functions = require('firebase-functions');
+const sendEmail = require('../sharedServices').sendEmail;
+const db = require('../sharedServices').db;
+
+const sendCandidateCreatedAccountEmail = async (snap, context) => {
+  const data = snap.data();
+  const email = data.email;
+
+  const candidateRef = db.collection('candidates').doc(context.params.candidateId);
+  const setWithMerge = candidateRef.set({
+    createdAt: Date.now(), 
+    status: "account-created",
+  }, { merge: true});
+
+  const personalizationData = {
+    fullName: data.fullName,
+  };  
+
+  const templateId = functions.config().notify.templates.candidate_created_account;
+  const sendEmailResponse = sendEmail(email, templateId, personalizationData);
+  if (sendEmailResponse) {
+    console.info(email + ' is a new candidate and created an account.');
+    return true;
+  } 
+  console.error(`Sending to ${email} candidate created account email failed.`)
+  return null; 
+}
+
+exports.handleOnCreate = functions.firestore
+  .document('candidates/{candidateId}')
+  .onCreate( (snap, context) => {
+    const candidateCreatedAccountEmailSent = sendCandidateCreatedAccountEmail(snap, context);
+    return null;
+  });

--- a/functions/candidates/handleCandidateOnCreate.js
+++ b/functions/candidates/handleCandidateOnCreate.js
@@ -10,7 +10,7 @@ const sendCandidateCreatedAccountEmail = async (snap, context) => {
   const candidateRef = db.collection('candidates').doc(context.params.candidateId);
   const setWithMerge = candidateRef.set({
     createdAt: Date.now(), 
-    status: "account-created",
+    status: 'account-created',
   }, { merge: true});
 
   const personalizationData = {
@@ -23,9 +23,9 @@ const sendCandidateCreatedAccountEmail = async (snap, context) => {
     console.info(email + ' is a new candidate and created an account.');
     return true;
   } 
-  console.error(`Sending to ${email} candidate created account email failed.`)
+  console.error(`Sending to ${email} candidate created account email failed.`);
   return null; 
-}
+};
 
 exports.handleOnCreate = functions.firestore
   .document('candidates/{candidateId}')

--- a/functions/index.js
+++ b/functions/index.js
@@ -15,6 +15,7 @@ const sendEmail = require('./sharedServices').sendEmail;
 
 exports.sendExerciseStartedEmail = require('./exercises/sendExerciseStartedEmail');
 exports.handleExerciseMailboxChange = require('./exercises/handleExerciseMailboxChange');
+exports.handleCandidateOnCreate = require('./candidates/handleCandidateOnCreate');
 
 /*
  *  TODO: All functions below this comment should be refactored into separate files.


### PR DESCRIPTION
When a new Candidate document is created, this cloud function:
- automatically generates field 'status' = 'account-created'
- automatically generates field 'createdAt' = Date.now()
- emails the candidate informing them that they've created a JAC account 

Assumptions - These fields are passed in from 'apply' Vue app when user fills in the form:
- dateOfBirth
- email (required)
- fullName (required)
- nationalInsuranceNumber
