### PR TITLE
Introducing slog slack logger

### DIFF
--- a/functions/exercises/handleExerciseMailboxChange.js
+++ b/functions/exercises/handleExerciseMailboxChange.js
@@ -3,6 +3,7 @@ const functions = require('firebase-functions');
 const sendEmail = require('../sharedServices').sendEmail;
 const emailIsValid = require('../sharedServices').emailIsValid;
 const db = require('../sharedServices').db;
+const slog = require('../sharedServices').slog;
 
 exports.handleExerciseMailboxChange = functions.firestore
   .document('exercises/{exerciseId}')
@@ -27,7 +28,7 @@ exports.handleExerciseMailboxChange = functions.firestore
         exerciseMailbox: previousEmail, 
       }, { merge: true});
 
-      console.error(`${email} is an invalid email format. Leaving email mailbox as ${previousEmail}`);
+      slog(`${email} is an invalid email format. Leaving email mailbox as ${previousEmail}`);
       return null;
     }
 
@@ -50,7 +51,7 @@ exports.handleExerciseMailboxChange = functions.firestore
     const templateId = functions.config().notify.templates.exercise_mailbox_changed;
 
     return sendEmail(email, templateId, personalizationData).then((sendEmailResponse) => {
-      console.info(`Exercise "${data.name}" - mailbox ${previousEmail} has been changed to ${email}`);
+      slog(`Exercise "${data.name}" - mailbox ${previousEmail} has been changed to ${email}`);
       return true;
     });
   });

--- a/functions/exercises/sendExerciseStartedEmail.js
+++ b/functions/exercises/sendExerciseStartedEmail.js
@@ -18,7 +18,7 @@ exports.sendExerciseStartedEmail = functions.firestore
 
     const templateId = functions.config().notify.templates.exercise_started;
     return sendEmail(email, templateId, {}).then((sendEmailResponse) => {
-      slog(`${email} has created an Exercise (${context.params.exerciseId})`)
+      slog(`${email} has created an Exercise (${context.params.exerciseId})`);
       return true;
     });
   });

--- a/functions/exercises/sendExerciseStartedEmail.js
+++ b/functions/exercises/sendExerciseStartedEmail.js
@@ -2,6 +2,7 @@
 const functions = require('firebase-functions');
 const sendEmail = require('../sharedServices').sendEmail;
 const db = require('../sharedServices').db;
+const slog = require('../sharedServices').slog;
 
 exports.sendExerciseStartedEmail = functions.firestore
   .document('exercises/{exerciseId}')
@@ -17,7 +18,7 @@ exports.sendExerciseStartedEmail = functions.firestore
 
     const templateId = functions.config().notify.templates.exercise_started;
     return sendEmail(email, templateId, {}).then((sendEmailResponse) => {
-      console.info(email + ' has created an Exercise.');
+      slog(`${email} has created an Exercise (${context.params.exerciseId})`)
       return true;
     });
   });

--- a/functions/sharedServices.js
+++ b/functions/sharedServices.js
@@ -67,14 +67,14 @@ const slog = async (msgString) => {
   // firebase functions:config:set slack.url="YOUR_SLACK_INCOMING_WEBHOOK_URL"  
   const slackUrl = functions.config().slack.url;
 
-  data = {
+  const data = {
     text: msgString,
-  }
+  };
   
   // we wait for the axios.post Promise to be resolved
   const result = axios.post(slackUrl, data);
   return result.data;
-}
+};
 
 module.exports = {
   db,

--- a/functions/sharedServices.js
+++ b/functions/sharedServices.js
@@ -72,7 +72,7 @@ const slog = async (msgString) => {
   };
   
   // we wait for the axios.post Promise to be resolved
-  const result = axios.post(slackUrl, data);
+  const result = await axios.post(slackUrl, data);
   return result.data;
 };
 

--- a/functions/sharedServices.js
+++ b/functions/sharedServices.js
@@ -1,5 +1,6 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
+const axios = require('axios');
 
 const NotifyClient = require('notifications-node-client').NotifyClient;
 
@@ -53,9 +54,32 @@ const getData = async (collectionName, docId) => {
   return data;
 };
 
+//
+//  helper function to log a string to Slack channel #prod-alerts
+//
+const slog = async (msgString) => {
+  console.log(msgString);
+
+  // Check that the firebase config has the key by running:
+  // firebase functions:config:get
+  //
+  // Set slack.url in firebase functions like this:
+  // firebase functions:config:set slack.url="YOUR_SLACK_INCOMING_WEBHOOK_URL"  
+  const slackUrl = functions.config().slack.url;
+
+  data = {
+    text: msgString,
+  }
+  
+  // we wait for the axios.post Promise to be resolved
+  const result = axios.post(slackUrl, data);
+  return result.data;
+}
+
 module.exports = {
   db,
   sendEmail,
   emailIsValid,
   getData,
+  slog,
 };


### PR DESCRIPTION
Since show and tell yesterday, people have been entering data into
the live Production database. It is not completely ready yet, but we
need a little monitoring in place, as we will be changing the document
structure drastically as we build out the new JAC system replacing JARS.

Instead of using console.log, use slog, which does 2 things:
- do a simple console.log
- writes the same string in console.log into a private slack channel #prod-alerts