### PR TITLE
#457 Security rules to allow application extension

### DIFF
--- a/database/firestore.rules
+++ b/database/firestore.rules
@@ -94,8 +94,10 @@ service cloud.firestore {
       // overide stored time and set to 13:00
       // @TODO Let's store time in database rather than having hardcoded all over and messing with DST
       // NB have added 12 hours rather than 13 as date is returned as +1 hour DST (at the moment)
-      return (get(/databases/$(database)/documents/exercises/$(exerciseId)).data.applicationOpenDate.date() + duration.time(13,0,0,0)) <= request.time
-        && (get(/databases/$(database)/documents/exercises/$(exerciseId)).data.applicationCloseDate.date() + duration.time(13,0,0,0)) > request.time;
+      let applicationOpenDate = get(/databases/$(database)/documents/exercises/$(exerciseId)).data.applicationOpenDate.date() + duration.time(13,0,0,0);
+      let applicationCloseDate = get(/databases/$(database)/documents/exercises/$(exerciseId)).data.applicationCloseDate.date() + duration.time(13,0,0,0);
+      return applicationOpenDate <= request.time
+				&& resource.data.get("dateExtension", applicationCloseDate) > request.time;
     }
 
     match /applications/{applicationId} {


### PR DESCRIPTION
## Tests ##
```
Close date | Extension date | Able to save? | Result
Future     | None           | Yes           | PASS
Past       | None           | No            | PASS
Past       | Future         | Yes           | PASS
Past       | Past           | No            | PASS
Future     | Future         | Yes           | PASS
Future     | Past           | Yes           | FAIL
```

**Note**
Currently if we have an extension date it will always override the exercise close date. This means that if an exercise is open but an application has an extension date set in the past then the candidate will be unable to amend their application. This might actually be useful behaviour however I have marked it as a FAIL in the tests above.