### PR TITLE
Feature/1282 edge case

### DIFF
--- a/functions/actions/qualifyingTests/scoreQualifyingTest.js
+++ b/functions/actions/qualifyingTests/scoreQualifyingTest.js
@@ -64,10 +64,11 @@ module.exports = (config, firebase, db) => {
         data.isOutOfTime = true;
         data.exitedTest = true;
         data.status = config.QUALIFYING_TEST_RESPONSES.STATUS.COMPLETED;
-        // TODO: if the endDate is smaller than ended use the endDate
-        // qualifyingTest.endDate < ended ? qualifyingTest.endDate : ended; 
-        data['statusLog.completed'] = endedTimestamp;
-        
+        if (qualifyingTest.endDate.toMillis() < endedTimestamp.toMillis()) {
+          data['statusLog.completed'] = qualifyingTest.endDate;  
+        } else {
+          data['statusLog.completed'] = endedTimestamp;
+        }
       }
       if (Object.keys(data).length > 0) {
         data.lastUpdated = firebase.firestore.FieldValue.serverTimestamp();


### PR DESCRIPTION
This is a complicated ticket to test, because you need direct access to the database

https://console.firebase.google.com/u/1/project/digital-platform-develop/firestore/data~2FqualifyingTests~2FpoUUaamsR5kJz1MsVYwN 
1. add  `endDate` to the database: 09/05/2021 11:59:59:59PM

https://console.firebase.google.com/u/1/project/digital-platform-develop/firestore/data~2FqualifyingTestResponses~2FVinJlWfy9kdnskURgq4O
1. Change the `status` to `started`
2. Delete the `statusLog.completed` date
3. add the date to `statusLog.completed` five minutes before the end 09/05/2021 11:54:59:59PM

On the console.log on the digital-platform repository
1. `npm run nodeScript scoreQualifyingTest`

RESULTS
The `statusLog.completed` date should be 09/05/2021 11:59:59:59PM
