### PR TITLE
Ensure authentication is called before validation

### DIFF
--- a/functions/callableFunctions/activateQualifyingTest.js
+++ b/functions/callableFunctions/activateQualifyingTest.js
@@ -5,13 +5,13 @@ const { checkArguments } = require('../shared/helpers.js');
 const activateQualifyingTest = require('../actions/qualifyingTests/activateQualifyingTest')(config, firebase, db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
   if (!checkArguments({
     qualifyingTestId: { required: true },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
-  }
-  if (!context.auth) {
-    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
   }
   return activateQualifyingTest(data);
 });

--- a/functions/callableFunctions/cancelAssessments.js
+++ b/functions/callableFunctions/cancelAssessments.js
@@ -5,13 +5,13 @@ const { checkArguments } = require('../shared/helpers.js');
 const { cancelAssessments } = require('../actions/assessments')(config, firebase, db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
   if (!checkArguments({
     exerciseId: { required: true },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
-  }
-  if (!context.auth) {
-    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
   }
   const result = await cancelAssessments(data);
   return {

--- a/functions/callableFunctions/flagApplicationIssuesForExercise.js
+++ b/functions/callableFunctions/flagApplicationIssuesForExercise.js
@@ -4,12 +4,12 @@ const { db } = require('../shared/admin.js');
 const flagApplicationIssues = require('../actions/applications/flagApplicationIssues')(config, db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
-  if (!(typeof data.exerciseId === 'string') || data.exerciseId.length === 0) {
-    throw new functions.https.HttpsError('invalid-argument', 'Please specify an "exerciseId"');
-  }
   // @TODO check auth.token for correct role, when we have implemented roles
   if (!context.auth) {
     throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
+  if (!(typeof data.exerciseId === 'string') || data.exerciseId.length === 0) {
+    throw new functions.https.HttpsError('invalid-argument', 'Please specify an "exerciseId"');
   }
   const result = await flagApplicationIssues.flagApplicationIssuesForExercise(data.exerciseId);
   return {

--- a/functions/callableFunctions/initialiseApplicationRecords.js
+++ b/functions/callableFunctions/initialiseApplicationRecords.js
@@ -7,13 +7,13 @@ const { generateDiversityReport } = require('../actions/exercises/generateDivers
 // const { flagApplicationIssuesForExercise } = require('../actions/applications/flagApplicationIssues')(config, db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
   if (!checkArguments({
     exerciseId: { required: true },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
-  }
-  if (!context.auth) {
-    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
   }
   const result = await initialiseApplicationRecords(data);
 

--- a/functions/callableFunctions/initialiseAssessments.js
+++ b/functions/callableFunctions/initialiseAssessments.js
@@ -5,14 +5,14 @@ const { checkArguments } = require('../shared/helpers.js');
 const { initialiseAssessments } = require('../actions/assessments')(config, firebase, db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
   if (!checkArguments({
     exerciseId: { required: true },
     stage: { required: true },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
-  }
-  if (!context.auth) {
-    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
   }
   const result = await initialiseAssessments(data);
   return {

--- a/functions/callableFunctions/initialiseMissingApplicationRecords.js
+++ b/functions/callableFunctions/initialiseMissingApplicationRecords.js
@@ -7,13 +7,13 @@ const { generateDiversityReport } = require('../actions/exercises/generateDivers
 // const { flagApplicationIssuesForExercise } = require('../actions/applications/flagApplicationIssues')(config, db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
   if (!checkArguments({
     exerciseId: { required: true },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
-  }
-  if (!context.auth) {
-    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
   }
   const result = await initialiseMissingApplicationRecords(data);
 

--- a/functions/callableFunctions/initialiseQualifyingTest.js
+++ b/functions/callableFunctions/initialiseQualifyingTest.js
@@ -5,15 +5,15 @@ const { checkArguments } = require('../shared/helpers.js');
 const initialiseQualifyingTest = require('../actions/qualifyingTests/initialiseQualifyingTest')(config, firebase, db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
   if (!checkArguments({
     qualifyingTestId: { required: true },
     stage: { required: false },
     status: { required: false },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
-  }
-  if (!context.auth) {
-    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
   }
   return initialiseQualifyingTest(data);
 });

--- a/functions/callableFunctions/scoreQualifyingTest.js
+++ b/functions/callableFunctions/scoreQualifyingTest.js
@@ -5,13 +5,13 @@ const { checkArguments } = require('../shared/helpers.js');
 const scoreQualifyingTest = require('../actions/qualifyingTests/scoreQualifyingTest')(config, firebase, db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
   if (!checkArguments({
     qualifyingTestId: { required: true },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
-  }
-  if (!context.auth) {
-    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
   }
   return scoreQualifyingTest(data);
 });

--- a/functions/callableFunctions/sendAssessmentReminders.js
+++ b/functions/callableFunctions/sendAssessmentReminders.js
@@ -5,15 +5,15 @@ const { checkArguments } = require('../shared/helpers.js');
 const { sendAssessmentReminders } = require('../actions/assessments')(config, firebase, db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
   if (!checkArguments({
     exerciseId: { required: true },
     assessmentId: { required: false },
     assessmentIds: { required: false },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
-  }
-  if (!context.auth) {
-    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
   }
   const result = await sendAssessmentReminders(data);
   return {

--- a/functions/callableFunctions/sendAssessmentRequests.js
+++ b/functions/callableFunctions/sendAssessmentRequests.js
@@ -5,6 +5,9 @@ const { checkArguments } = require('../shared/helpers.js');
 const { sendAssessmentRequests } = require('../actions/assessments')(config, firebase, db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
   if (!checkArguments({
     exerciseId: { required: true },
     assessmentId: { required: false },
@@ -12,9 +15,6 @@ module.exports = functions.region('europe-west2').https.onCall(async (data, cont
     resend: { required: false },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
-  }
-  if (!context.auth) {
-    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
   }
   const result = await sendAssessmentRequests(data);
   return {

--- a/functions/callableFunctions/sendCharacterCheckRequests.js
+++ b/functions/callableFunctions/sendCharacterCheckRequests.js
@@ -5,13 +5,13 @@ const { checkArguments } = require('../shared/helpers.js');
 const { sendCharacterCheckRequests } = require('../actions/applications/applications')(config, firebase, db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
   if (!checkArguments({
     items: { required: true },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
-  }
-  if (!context.auth) {
-    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
   }
   const result = await sendCharacterCheckRequests(data);
   return result;

--- a/functions/callableFunctions/sendQualifyingTestReminders.js
+++ b/functions/callableFunctions/sendQualifyingTestReminders.js
@@ -5,13 +5,13 @@ const { checkArguments } = require('../shared/helpers.js');
 const sendQualifyingTestReminders = require('../actions/qualifyingTests/sendQualifyingTestReminders')(config, firebase, db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
   if (!checkArguments({
     qualifyingTestId: { required: true },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
-  }
-  if (!context.auth) {
-    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
   }
   const result = await sendQualifyingTestReminders(data);
   return result;

--- a/functions/callableFunctions/testAssessmentNotification.js
+++ b/functions/callableFunctions/testAssessmentNotification.js
@@ -5,14 +5,14 @@ const { checkArguments } = require('../shared/helpers.js');
 const { testAssessmentNotification } = require('../actions/assessments')(config, firebase, db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
   if (!checkArguments({
     assessmentId: { required: true },
     notificationType: { required: true },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
-  }
-  if (!context.auth) {
-    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
   }
   const result = await testAssessmentNotification({
     assessmentId: data.assessmentId,

--- a/functions/callableFunctions/transferHandoverData.js
+++ b/functions/callableFunctions/transferHandoverData.js
@@ -5,13 +5,13 @@ const { checkArguments } = require('../shared/helpers.js');
 const transferHandoverData = require('../actions/exercises/transferHandoverData')(config, firebase, db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
   if (!checkArguments({
     exerciseId: { required: true },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
-  }
-  if (!context.auth) {
-    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
   }
   return transferHandoverData(data);
 });


### PR DESCRIPTION
This is to ensure that the request is authenticated before any validation is performed - as otherwise an attacker could possibly infer what these functions do by what data they supply even without being authenticated.

This could do with being in a helper function that throws something so we don't have any duplication except for 1 function call.