### PR TITLE
#546 Bugfix: Should be able to initialise a QT

### DIFF
--- a/functions/shared/factories/QualifyingTests/newQualifyingTestResponse.js
+++ b/functions/shared/factories/QualifyingTests/newQualifyingTestResponse.js
@@ -8,7 +8,7 @@ module.exports = (config, firebase) => {
       qualifyingTest: {
         id: qualifyingTest.id,
         type: qualifyingTest.type,
-        isTieBreaker: qualifyingTest.isTieBreaker,
+        isTieBreaker: qualifyingTest.isTieBreaker ? qualifyingTest.isTieBreaker : false,
         title: qualifyingTest.title,
         startDate: qualifyingTest.startDate,
         endDate: qualifyingTest.endDate,


### PR DESCRIPTION
Closes #546 

Callable function `initialiseQualifyingTest` was returning the following error:

```
Cannot use "undefined" as a Firestore value (found in field "qualifyingTest.isTieBreaker"
```

This PR fixes that.