### PR TITLE
#574 Enable application form to be configured

### DIFF
--- a/functions/shared/factories.js
+++ b/functions/shared/factories.js
@@ -195,6 +195,7 @@ module.exports = (CONSTANTS) => {
       aboutTheRole: null,
       additionalWorkingPreferences: null,
       applicationCloseDate: null,
+      applicationContent: null,
       applicationOpenDate: null,
       appliedSchedule: null,
       appointmentType: null,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint . --fix",
     "serve": "firebase serve --only functions",
     "shell": "firebase functions:shell",
+    "emulators:firestore": "firebase emulators:start --only firestore",
     "start": "npm run shell",
     "logs": "firebase functions:log",
     "nodeScript": "export GOOGLE_APPLICATION_CREDENTIALS='service-account.json' && run(){ node -r dotenv/config nodeScripts/$1; }; run",


### PR DESCRIPTION
Copies the new `applicationContent` field from `exercises` to `vacancies`. This helps to enable Apply form to be configurable.

Plus adds an package script for `npm run emulators:firestore`