### PR TITLE
#293 Search should update when data changes

### DIFF
--- a/functions/actions/candidates/personalDetails/onUpdate.js
+++ b/functions/actions/candidates/personalDetails/onUpdate.js
@@ -1,7 +1,7 @@
 const { applyUpdates } = require('../../../shared/helpers');
 
 module.exports = (config, firebase, db) => {
-  const { updateCandidate } = require('../search')(db);
+  const { updateCandidate } = require('../search')(firebase, db);
 
   return onUpdate;
 
@@ -11,9 +11,9 @@ module.exports = (config, firebase, db) => {
   async function onUpdate(candidateId, dataBefore, dataAfter) {
 
     // update candidate document
-    await updateCandidate(candidateId);
+    const result = await updateCandidate(candidateId);
 
-    return true;
+    return result;
   }
 
 };

--- a/functions/actions/candidates/search.js
+++ b/functions/actions/candidates/search.js
@@ -13,12 +13,12 @@ module.exports = (firebase, db) => {
 
   /**
    * Update candidate document with full search & relationships data
-   * @returns boolean (true => success)
+   * @returns number|false (number > 0 => success)
    */
   async function updateCandidate(candidateId) {
     if (!candidateId) { return false; }
     const qtyUpdated = await updateAllCandidates(candidateId);
-    return qtyUpdated !== false;
+    return qtyUpdated || false;
   }
 
   /**
@@ -37,7 +37,7 @@ module.exports = (firebase, db) => {
         candidates.push(candidate);
       }
     } else {
-      candidates = await getDocuments(db.collection('candidates').orderBy('created'));
+      candidates = await getDocuments(db.collection('candidates'));
     }
     for (let i = 0, len = candidates.length; i < len; ++i) {
       candidateData[candidates[i].id] = {};


### PR DESCRIPTION
This PR fixes a bug where candidate search data was not being updated when candidate personal details were updated.

Can be tested in Admin and firestore console:
 - Locate a candidate document in Admin
 - Open the corresponding `candidates` document in firestore console
 - Edit the name of the candidate
 - Observe in firestore console that the `lastUpdated` and `computed` fields in `candidates` document get updated (previously this was not happening)
  