### PR TITLE
#574 Replace vacancy data rather than merge

### DIFF
--- a/functions/actions/vacancies.js
+++ b/functions/actions/vacancies.js
@@ -26,12 +26,12 @@ module.exports = (config, db) => {
   async function updateVacancy(vacancyId, data) {
     const vacancy = newVacancy(data);
     try {
-      await db.collection('vacancies').doc(vacancyId).set(vacancy, { merge: true });
+      await db.collection('vacancies').doc(vacancyId).set(vacancy);
       return true;
     } catch (e) {
       console.error(`Error writing vacancy ${vacancyId}`, e);
       return false;
     }
-  }  
+  }
 
 };

--- a/functions/backgroundFunctions/onExerciseUpdate.js
+++ b/functions/backgroundFunctions/onExerciseUpdate.js
@@ -8,7 +8,7 @@ module.exports = functions.region('europe-west2').firestore
   .onUpdate(async (change, context) => {
     const after = change.after.data();
     const before = change.before.data();
-    
+
     // TODO:-
     // We may need to perform more than one task/check.
     // Consider whether to do them here, in seperate cloud functions, or


### PR DESCRIPTION
When an `exercises` document changes we copy some of the data across to the corresponding `vacancies` document.
Previously this merged the changes into the vacancy document, which meant that 'old data' was retained in the document.
This PR fixes that by ensuring the vacancy document is replaced each time there is a change.