### PR TITLE
admin#1363 Ensure partial applications can be exported

### DIFF
--- a/functions/actions/exercises/exportApplicationContactsData.js
+++ b/functions/actions/exercises/exportApplicationContactsData.js
@@ -55,6 +55,9 @@ module.exports = (firebase, db) => {
 
 const contactsExport = (applications) => {
   return applications.map((application) => {
+    // the following ensure application has sufficient fields for the export
+    if (!Object.keys(application).includes('personalDetails')) { application.personalDetails = {}; }
+    if (!Object.keys(application).includes('equalityAndDiversitySurvey')) { application.equalityAndDiversitySurvey = {}; }
     return {
       referenceNumber: application.referenceNumber,
       status: lookup(application.status),


### PR DESCRIPTION
This PR ensures our 'Export contacts' feature works for applications having minimal data. As part of Staged Applications it is now possible to have valid Applied applications without `personalDetails`, `equalityAndDiversitySurvey` etc.

To test log in to Admin (develop) and ensure the 'Export contacts' button in Applications list successfully allows a download of data