### PR TITLE
admin#1346 Copy exercise state to vacancy

### DIFF
--- a/functions/shared/factories.js
+++ b/functions/shared/factories.js
@@ -261,6 +261,7 @@ module.exports = (CONSTANTS) => {
       situationalJudgementTestDate: null,
       situationalJudgementTestEndTime: null,
       situationalJudgementTestStartTime: null,
+      state: null,
       subscriberAlertsUrl: null,
       typeOfExercise: null,
       uploadedCandidateAssessmentFormTemplate: null,


### PR DESCRIPTION
Copies exercise state across to corresponding vacancy document.

This is useful for the Staged Applications epic where we will request additional data from the candidate at different exercise states.

See this PR for the corresponding UI work: https://github.com/jac-uk/admin/pull/1364

## To test

Open firebase console in two browser windows, so you can see each window side by side.
In one window, open a test `exercise` document.
In the other window open the corresponding `vacancy` document.

Change the exercise `state` field - e.g. change it from "approved" to "shortlisting"

Notice that the vacancy `state` field also changes to the same value.
