### PR TITLE
#592 Support application process

### DIFF
--- a/database/firestore.rules
+++ b/database/firestore.rules
@@ -101,6 +101,12 @@ service cloud.firestore {
       return applicationOpenDate <= request.time
 				&& request.resource.data.get("dateExtension", applicationCloseDate) > request.time;
     }
+    function exerciseNeedsMoreInformation(exerciseId) {
+      let exercise = get(/databases/$(database)/documents/exercises/$(exerciseId)).data;
+      return exercise.keys().hasAll(['state', 'applicationContent'])
+        && exercise.state in exercise.applicationContent
+        && exercise.applicationContent[exercise.state].keys().size() > 0;
+    }
 
     match /applications/{applicationId} {
       // allow admins full read access to all applications
@@ -115,9 +121,18 @@ service cloud.firestore {
       // But only if the application is in 'draft' state and exercise is open
       allow update: if resource.data.userId == currentUser() &&
                        request.resource.data.userId == currentUser() &&
-                       resource.data.status == "draft" &&
-                       request.resource.data.status in ['draft', 'applied'] &&
-                       exerciseIsOpen(resource.data.exerciseId);
+                       (
+                         (  // draft application for an open vacancy
+                            resource.data.status == "draft" &&
+                            request.resource.data.status in ['draft', 'applied'] &&
+                            exerciseIsOpen(resource.data.exerciseId)
+                         )
+                         ||
+                         (  // current application with more info requested
+                            resource.data.status == "applied" && request.resource.data.status == "applied" &&  // remains in applied status
+                            exerciseNeedsMoreInformation(resource.data.exerciseId)
+                         )
+                       );
       // allow JAC admins to edit an application @TODO restrict what can be changed and by which role
       allow update: if userIsAuthenticated() && userIsJAC();
     }

--- a/functions/backgroundFunctions/onExerciseUpdate.js
+++ b/functions/backgroundFunctions/onExerciseUpdate.js
@@ -8,20 +8,8 @@ module.exports = functions.region('europe-west2').firestore
   .onUpdate(async (change, context) => {
     const after = change.after.data();
     const before = change.before.data();
-
-    // TODO:-
-    // We may need to perform more than one task/check.
-    // Consider whether to do them here, in seperate cloud functions, or
-    // perhaps use Pub/Sub.
     if (after.published === true) {
-      if (
-        before.published !== true || (
-          before.published === true &&
-          (before.state === 'draft' || before.state === 'ready')
-        )
-      ) {
-        return updateVacancy(context.params.exerciseId, after);
-      }
+      return updateVacancy(context.params.exerciseId, after);
     } else if (after.published === false) {
       if (before.published === true) {
         return deleteVacancy(context.params.exerciseId);

--- a/test/rules/helpers.js
+++ b/test/rules/helpers.js
@@ -1,5 +1,6 @@
 const firebase = require('@firebase/rules-unit-testing');
 const fs = require('fs');
+const admin = require('firebase-admin');
 
 const projectId = `rules-spec-${Date.now()}`;
 
@@ -52,5 +53,5 @@ module.exports.setupAdmin = async (db, data) => {
 };
 
 module.exports.getTimeStamp = (date) => {
-  return firebase.firestore.Timestamp.fromDate(date);
+  return admin.firestore.Timestamp.fromDate(date);
 };


### PR DESCRIPTION
This PR covers the following:

Ensures `vacancy` documents to stay up to date with all exercise changes. Previously the vacancy was not updated after the exercise had been approved, as no changes were happening. Now the exercise changes state and this should be synced to the vacancy.

Updates our security rules for firestore to allow candidates to add extra content to their application **when** the vacancy requires it. Have included main tests covering this scenario.

Fixes an incompatibility with the new `@firebase/rules-unit-testing` package where it allows the creation of timestamps that are incompatible with firestore. So have updated our helper to use `firebase-admin` to create timestamps instead.