### PR TITLE
#419 Populate application records with diversity data

### DIFF
--- a/functions/shared/factories.js
+++ b/functions/shared/factories.js
@@ -148,6 +148,73 @@ module.exports = (CONSTANTS) => {
     return assessment;
   }
 
+  function newDiversityFlags(application) {
+    const applicationData = application.equalityAndDiversitySurvey ? application.equalityAndDiversitySurvey : application;
+    const data = {
+      gender: applicationData.gender,
+      ethnicity: null,
+      disability: applicationData.disability,
+      professionalBackground: {
+        barrister: null,
+        cilex: null,
+        solicitor: null,
+        other: null,
+        preferNotToSay: null,
+      },
+      socialMobility: {
+        attendedUKStateSchool: null,
+        firstGenerationUniversity: null,
+      },
+    };
+    if (applicationData.ethnicGroup) {
+      switch (applicationData.ethnicGroup) {
+        case 'uk-ethnic':
+        case 'irish':
+        case 'gypsy-irish-traveller':
+        case 'other-white':
+          data.ethnicity = 'white';
+          break;
+        case 'prefer-not-to-say':
+          data.ethnicity = applicationData.ethnicGroup;
+          break;
+        case 'other-ethnic-group':
+          data.ethnicity = applicationData.ethnicGroup;
+          break;
+        default: // @todo check catch all is appropriate for bame
+          data.ethnicity = 'bame';
+      }
+    }
+    if (applicationData.professionalBackground && applicationData.professionalBackground.length) {
+      if (applicationData.professionalBackground.indexOf('barrister') >= 0) {
+        data.professionalBackground.barrister = true;
+      }
+      if (applicationData.professionalBackground.indexOf('cilex') >= 0) {
+        data.professionalBackground.cilex = true;
+      }
+      if (applicationData.professionalBackground.indexOf('solicitor') >= 0) {
+        data.professionalBackground.solicitor = true;
+      }
+      if (applicationData.professionalBackground.indexOf('other-professional-background') >= 0) {
+        data.professionalBackground.other = true;
+      }
+      if (applicationData.professionalBackground.indexOf('prefer-not-to-say') >= 0) {
+        data.professionalBackground.preferNotToSay = true;
+      }
+    }
+
+    if (
+      application.stateOrFeeSchool === 'uk-state-selective'
+      || application.stateOrFeeSchool === 'uk-state-non-selective'
+    ) {
+      data.socialMobility.attendedUKStateSchool = true;
+    }
+    if (application.firstGenerationStudent === true) {
+      data.socialMobility.firstGenerationUniversity = true;
+    }
+
+    return data;
+  }
+
   function newApplicationRecord(exercise, application) {
     let applicationRecord = {
       exercise: {
@@ -178,6 +245,7 @@ module.exports = (CONSTANTS) => {
         characterIssues: [],
         eligibilityIssues: [],
       },
+      diversity: newDiversityFlags(application),
       history: [],
       notes: [],
     };


### PR DESCRIPTION
## What's included?

When a new applicationRecord document is created in firestore, it now includes the diversity data

## Who should test?
✅ Developers

## How to test?

### Cut off scores
- Apply for a vacancy then process the applications from the admin.
- Check that the diversity data is included within the applicationRecord document


## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
