### PR TITLE
#473 purge backups after 30 days

### DIFF
--- a/functions/actions/backup/authentication.js
+++ b/functions/actions/backup/authentication.js
@@ -9,7 +9,7 @@ const path = require('path');
 
 module.exports = (config) => {
   const BACKUP_BUCKET = `${config.PROJECT_ID}-backups`;
-  const BACKUP_PATH = 'authentication/';
+  const BACKUP_PATH = 'authentication';
   const PROJECT_ID = config.PROJECT_ID;
   const slack = require('../../shared/slack')(config);
   return {
@@ -17,24 +17,44 @@ module.exports = (config) => {
   };
 
   async function backupAuthentication() {
+
     // Download auth export file to the local filesystem
     const downloadAuthExport = async (filePath) => {
+      console.log('Downloading ' + filePath + '...');
       await firebaseTools.auth.export(filePath, {
         project: PROJECT_ID,
       });
     };
 
+    const bucket = admin.storage().bucket(BACKUP_BUCKET);
+
     // Upload local file to the backup Cloud Storage bucket
     const uploadToStorageBucket = async (localPath, fileName) => {
-      const bucket = admin.storage().bucket(BACKUP_BUCKET);
+      console.log('Uploading ' + fileName + '...');
       await bucket.upload(localPath, {
-        destination: BACKUP_PATH + fileName,
+        destination: BACKUP_PATH + '/' + fileName,
       });
     };
 
     // Delete a file from the local filesystem
     const deleteLocalFile = (filePath) => {
       return fs.unlinkSync(filePath);
+    };
+
+    // Delete all backup files more than 30 days old
+    const purgeBackupHistory = async () => {
+      console.log('Purging backup history...');
+      const thirtyDaysAgo = new Date();
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+      const [files] = await bucket.getFiles({
+        'prefix': BACKUP_PATH,
+      });
+      files.forEach(file => {
+        if (file.name < `${BACKUP_PATH}/${thirtyDaysAgo.toISOString()}.json`) { // each backup is a file named as a timestamp converted to ISO strings
+          console.log('Deleting ' + file.name);
+          file.delete();
+        }
+      });
     };
 
     const timestamp = (new Date()).toISOString();
@@ -45,11 +65,13 @@ module.exports = (config) => {
       await downloadAuthExport(tempFilePath);
       await uploadToStorageBucket(tempFilePath, fileName);
       deleteLocalFile(tempFilePath);
+      await purgeBackupHistory();
     } catch (err) {
       slack.post('ERROR: Authentication backup failed');
       slack.post(err);
       console.log('backupAuthentication error', err);
       throw new Error('Export operation failed');
     }
+
   }
 };

--- a/functions/actions/backup/firestore.js
+++ b/functions/actions/backup/firestore.js
@@ -3,6 +3,7 @@
  */
 const firestore = require('@google-cloud/firestore');
 const client = new firestore.v1.FirestoreAdminClient();
+const admin = require('firebase-admin');
 
 module.exports = (config) => {
   const slack = require('../../shared/slack')(config);
@@ -11,20 +12,47 @@ module.exports = (config) => {
   };
 
   async function backupFirestore() {
-    const bucket = `gs://${config.PROJECT_ID}-backups/firestore/${(new Date()).toISOString()}`;
+
+    const BACKUP_BUCKET = `${config.PROJECT_ID}-backups`;
+    const BACKUP_PATH = 'firestore';
+
+    const exportPath = `gs://${BACKUP_BUCKET}/${BACKUP_PATH}/${(new Date()).toISOString()}`;
     const databaseName = client.databasePath(config.PROJECT_ID, '(default)');
+
     try {
+      console.log('Exporting firestore (i.e., taking database backup)...');
       const responses = await client.exportDocuments({
         name: databaseName,
-        outputUriPrefix: bucket,
+        outputUriPrefix: exportPath,
         collectionIds: [],
       });
       const response = responses[0];
-      slack.post(`SUCCESS: Firestore backup to ${bucket} succeeded`);
+      slack.post(`SUCCESS: Firestore backup to ${exportPath} succeeded`);
       console.log(`Operation Name: ${response['name']}`);
+
+      // Delete all backup files more than 30 days old
+      console.log('Purging backup history...');
+      const thirtyDaysAgo = new Date();
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+      const bucket = admin.storage().bucket(BACKUP_BUCKET);
+      const [folders] = await bucket.getFiles({
+        'prefix': BACKUP_PATH,
+      });
+      // const [folders] = await admin.storage().getBuckets({
+      //   'prefix': `${BACKUP_BUCKET}/${BACKUP_PATH}`,
+      // });
+      folders.forEach(async (folder) => {
+        console.log('Processing folder: ' + folder.name);
+        if (folder.name < `${BACKUP_PATH}/${thirtyDaysAgo.toISOString()}`) { // each backup is contained within a folder named as a timestamp converted to ISO strings
+          console.log('Deleting ' + folder.name);
+          // await folder.delete();
+        }
+      });
+
       return response;
+
     } catch (err) {
-      slack.post(`ERROR: Firestore backup to ${bucket} failed`);
+      slack.post(`ERROR: Firestore backup to ${exportPath} failed`);
       slack.post(err);
       console.log('backupFirestore error', err);
       throw new Error('Export operation failed');

--- a/functions/actions/backup/firestore.js
+++ b/functions/actions/backup/firestore.js
@@ -34,13 +34,13 @@ module.exports = (config) => {
       console.log('Purging backup history...');
       const thirtyDaysAgo = new Date();
       thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-      const bucket = admin.storage().bucket(BACKUP_BUCKET);
-      const [folders] = await bucket.getFiles({
-        'prefix': BACKUP_PATH,
-      });
-      // const [folders] = await admin.storage().getBuckets({
-      //   'prefix': `${BACKUP_BUCKET}/${BACKUP_PATH}`,
+      // const bucket = admin.storage().bucket(BACKUP_BUCKET);
+      // const [folders] = await bucket.getFiles({
+      //   'prefix': BACKUP_PATH,
       // });
+      const [folders] = await admin.storage().getBuckets({
+        'prefix': `${BACKUP_BUCKET}/${BACKUP_PATH}`,
+      });
       folders.forEach(async (folder) => {
         console.log('Processing folder: ' + folder.name);
         if (folder.name < `${BACKUP_PATH}/${thirtyDaysAgo.toISOString()}`) { // each backup is contained within a folder named as a timestamp converted to ISO strings

--- a/functions/actions/backup/firestore.js
+++ b/functions/actions/backup/firestore.js
@@ -38,7 +38,7 @@ module.exports = (config) => {
       const bucket = admin.storage().bucket(BACKUP_BUCKET);
       // delete files in the firestore directory that start with the date 30 days ago
       await bucket.deleteFiles({
-        prefix: `firestore/${dateThirtyDaysAgo}`,
+        prefix: `${BACKUP_PATH}/${dateThirtyDaysAgo}`,
       });
       slack.post(`SUCCESS: Firestore backup from ${dateThirtyDaysAgo} purged successfully`);
       return true;

--- a/functions/actions/backup/firestore.js
+++ b/functions/actions/backup/firestore.js
@@ -34,22 +34,14 @@ module.exports = (config) => {
       console.log('Purging backup history...');
       const thirtyDaysAgo = new Date();
       thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-      // const bucket = admin.storage().bucket(BACKUP_BUCKET);
-      // const [folders] = await bucket.getFiles({
-      //   'prefix': BACKUP_PATH,
-      // });
-      const [folders] = await admin.storage().getBuckets({
-        'prefix': `${BACKUP_BUCKET}/${BACKUP_PATH}`,
+      const dateThirtyDaysAgo = thirtyDaysAgo.toISOString().split('T')[0];
+      const bucket = admin.storage().bucket(BACKUP_BUCKET);
+      // delete files in the firestore directory that start with the date 30 days ago
+      await bucket.deleteFiles({
+        prefix: `firestore/${dateThirtyDaysAgo}`,
       });
-      folders.forEach(async (folder) => {
-        console.log('Processing folder: ' + folder.name);
-        if (folder.name < `${BACKUP_PATH}/${thirtyDaysAgo.toISOString()}`) { // each backup is contained within a folder named as a timestamp converted to ISO strings
-          console.log('Deleting ' + folder.name);
-          // await folder.delete();
-        }
-      });
-
-      return response;
+      slack.post(`SUCCESS: Firestore backup from ${dateThirtyDaysAgo} purged successfully`);
+      return true;
 
     } catch (err) {
       slack.post(`ERROR: Firestore backup to ${exportPath} failed`);

--- a/functions/scheduledFunctions/backupAuthentication.js
+++ b/functions/scheduledFunctions/backupAuthentication.js
@@ -1,7 +1,9 @@
 const config = require('../shared/config');
-const SCHEDULE = 'every day 23:01';
 const functions = require('firebase-functions');
 const { backupAuthentication } = require('../actions/backup/authentication')(config);
+
+const SCHEDULE = 'every day 23:00';
+// const SCHEDULE = 'every 5 minutes';
 
 module.exports = functions.region('europe-west2')
   .pubsub

--- a/functions/scheduledFunctions/backupAuthentication.js
+++ b/functions/scheduledFunctions/backupAuthentication.js
@@ -3,7 +3,6 @@ const functions = require('firebase-functions');
 const { backupAuthentication } = require('../actions/backup/authentication')(config);
 
 const SCHEDULE = 'every day 23:00';
-// const SCHEDULE = 'every 5 minutes';
 
 module.exports = functions.region('europe-west2')
   .pubsub

--- a/functions/scheduledFunctions/backupFirestore.js
+++ b/functions/scheduledFunctions/backupFirestore.js
@@ -1,8 +1,9 @@
-const functions = require('firebase-functions');
 const config = require('../shared/config');
+const functions = require('firebase-functions');
 const { backupFirestore } = require('../actions/backup/firestore')(config);
 
-const SCHEDULE = 'every day 23:00';
+const SCHEDULE = 'every day 23:01';
+// const SCHEDULE = 'every 5 minutes';
 
 module.exports = functions.region('europe-west2')
   .pubsub

--- a/functions/scheduledFunctions/backupFirestore.js
+++ b/functions/scheduledFunctions/backupFirestore.js
@@ -3,7 +3,6 @@ const functions = require('firebase-functions');
 const { backupFirestore } = require('../actions/backup/firestore')(config);
 
 const SCHEDULE = 'every day 23:01';
-// const SCHEDULE = 'every 5 minutes';
 
 module.exports = functions.region('europe-west2')
   .pubsub


### PR DESCRIPTION
Code review only please. The idea is that after 30 days, old backups are deleted from storage.

There are 2 different methods for this.

Authentication exports to a single file so processing the deletes is quick and easy. We check for anything older than 30 days.

Firestore exports to a folder with lots of files inside it each time. Here we are simply deleting anything that starts with the date today - 30 days, so each day, the export from 30 days ago is deleted.