### PR TITLE
#257 Refine database security rules and write more tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ out/
 
 #Firestore data for emulation
 /data/firestore.json
+/data/firestore_export/
+/data/firebase-export-metadata.json

--- a/.gitignore
+++ b/.gitignore
@@ -102,4 +102,7 @@ output.csv
 out/
 
 # Local nodeScripts
-/nodeScripts/local
+/nodeScripts/
+
+#Firestore data for emulation
+/data/firestore.json

--- a/README.md
+++ b/README.md
@@ -17,6 +17,33 @@ See [database/firestore.indexes.json](database/firestore.indexes.json) for our c
 
 See [storage/storage.rules](storage/storage.rules) for our current rules.
 
+
+To run the emulator on your local machine, create a `./data/firestore.json` file with the contents of `[]`.
+Install the dependency for this script globally:
+
+``` npm install -g node-firestore-import-export```
+
+Once installed, you can run `npm run db:export` to get a copy of the current `digital-platform-develop` repository, which will save
+a deep copy of the entire firestore DB into the `/data/firestore.json` file. Be aware this does cause a read for every document collection on google cloud.
+
+Set up the emulators by running `npm run firestore` which will just boot up the firestore gcloud emulation. You may need to
+install this by following [this guide](https://firebase.google.com/docs/firestore/security/test-rules-emulator#install_the_emulator).
+This will run on port **8282** to avoid port conflicts. The interface, however, will run on **4000** as normal.
+Once the emulator is running, you may import the local copy made into the emulator with
+
+```npm run db:emulator:import```
+
+This command will set the environment variables and import into the local copy. You only need to do this once,
+data will be re-exported and then automatically imported on restart of the firestore emulator.
+
+To run the jest tests with `npm run test:rules` against your local emulator, you'll have to export or set the environment variable.
+
+```set FIRESTORE_EMULATOR_HOST=localhost:8282```
+
+```export FIRESTORE_EMULATOR_HOST="localhost:8282"```
+
+depending on your operating system.
+
 ## Functions
 
 See [functions/backgroundFunctions](functions/backgroundFunctions) for our functions which are triggered when defined events happen.

--- a/database/firestore.rules
+++ b/database/firestore.rules
@@ -10,15 +10,13 @@ service cloud.firestore {
   }
 
   function userIsJAC() {
-    return request.auth.token.email.matches('(.*@judicialappointments|.*@justice)[.](digital|gov[.]uk)');
-    //return request.auth.token.email_verified
-      //&& request.auth.token.email.matches('.*@judicialappointments[.](digital|gov[.]uk)');
+    return request.auth.token.email_verified
+      && request.auth.token.email.matches('(.*@judicialappointments|.*@justice)[.](digital|gov[.]uk)');
   }
 
   function userHasEmail(email) {
-  return request.auth.token.email.lower() == email.lower();
-    //return request.auth.token.email_verified
-      //&& request.auth.token.email.lower() == email.lower();
+    return request.auth.token.email_verified
+      && request.auth.token.email.lower() == email.lower();
   }
 
   function fieldHasValue(data, field, value) {
@@ -30,6 +28,11 @@ service cloud.firestore {
   //     || resource.data[field] == request.resource.data[field]
   // }
 
+  function verifyFields(required, optional) {
+    let all = required.concat(optional);
+    return request.resource.data.keys().hasAll(required) && request.resource.data.keys().hasOnly(all);
+  }
+
   match /databases/{database}/documents {
 
     match /{document=**} {
@@ -38,8 +41,8 @@ service cloud.firestore {
     }
 
     match /exercises/{exerciseId} {
-      allow read: if userIsAuthenticated() && userIsJAC();
-      allow write: if userIsAuthenticated() && userIsJAC();
+      allow create, update: if userIsAuthenticated() && userIsJAC() && verifyFields(['referenceNumber', 'progress', 'state', 'createdBy'], []);
+      allow read, delete: if userIsAuthenticated() && userIsJAC();
 
       match /reports/{reportId} {
         allow read: if userIsAuthenticated() && userIsJAC();
@@ -53,7 +56,8 @@ service cloud.firestore {
 
     match /notes/{noteId} {
       allow read: if userIsAuthenticated() && userIsJAC();
-      allow write: if userIsAuthenticated() && userIsJAC();
+      allow create, update: if userIsAuthenticated() && userIsJAC() && verifyFields(['body', 'createdBy'], []);
+      allow delete: if userIsAuthenticated() && userIsJAC();
     }
 
     match /panels/{panelId} {
@@ -106,8 +110,8 @@ service cloud.firestore {
     function exerciseIsOpen(exerciseId) {
       let applicationOpenDate = get(/databases/$(database)/documents/exercises/$(exerciseId)).data.applicationOpenDate;
       let applicationCloseDate = get(/databases/$(database)/documents/exercises/$(exerciseId)).data.applicationCloseDate;
-      return applicationOpenDate <= request.time
-				&& request.resource.data.get("dateExtension", applicationCloseDate) > request.time;
+      return applicationOpenDate <= int(request.time.toMillis())
+				&& request.resource.data.get("dateExtension", applicationCloseDate) > int(request.time.toMillis());
     }
     function exerciseNeedsMoreInformation(exerciseId) {
       let exercise = get(/databases/$(database)/documents/exercises/$(exerciseId)).data;
@@ -124,20 +128,22 @@ service cloud.firestore {
       // Allow existing records which belong to the current user
       allow read: if resource.data.userId == currentUser();
 
-      // Allow new records if they will belong to the current user, are draft and the exercise is open
+      // Allow new records if they will belong to the current user, are draft and the exercise is open, and we have valid fields
       allow create: if request.resource.data.userId == currentUser() &&
         request.resource.data.status == "draft" &&
-        exerciseIsOpen(request.resource.data.exerciseId);
+        exerciseIsOpen(request.resource.data.exerciseId) &&
+        verifyFields(['userId', 'exerciseId', 'status'], []);
 
       // Allow updates on records which belong, and will continue to belong, to the current user
-      // But only if the application is in 'draft' state and exercise is open
+      // But only if the application is in 'draft' state and exercise is open, and there are valid fields
       allow update: if resource.data.userId == currentUser() &&
         request.resource.data.userId == currentUser() &&
         (
           (  // draft application for an open vacancy
             resource.data.status == "draft" &&
             request.resource.data.status in ['draft', 'applied'] &&
-            exerciseIsOpen(resource.data.exerciseId)
+            exerciseIsOpen(resource.data.exerciseId) &&
+            verifyFields(['userId', 'exerciseId', 'status'], [])
           )
           ||
           (  // current application with more info requested
@@ -185,7 +191,8 @@ service cloud.firestore {
         (!('id' in request.resource.data.assessor) || request.resource.data.assessor.id == currentUser()) &&
         resource.data.assessor.email == request.resource.data.assessor.email &&
         resource.data.status == 'pending' &&
-        request.resource.data.status == 'completed';
+        request.resource.data.status == 'completed' &&
+        int(request.time.toMillis()) <= int(resource.data.dueDate);
         // TODO allow uploads after the due date but before the hard limit resource.data.dueDate >= request.time;
     }
 
@@ -194,7 +201,7 @@ service cloud.firestore {
       allow read: if userIsAuthenticated() && userIsJAC();
       allow create: if userIsAuthenticated() && userIsJAC();
       allow update: if userIsAuthenticated() && userIsJAC();
-      allow delete: if userIsAuthenticated() && userIsJAC();  // TODO only super admins
+      allow delete: if false;  // TODO only super admins
     }
 
     match /qualifyingTestReports/{qualifyingTestReportId} {

--- a/firebase.json
+++ b/firebase.json
@@ -8,7 +8,7 @@
   },
   "emulators": {
     "firestore": {
-      "port": 8080
+      "port": 8282
     },
     "functions": {
       "port": 5001

--- a/functions/callableFunctions/ensureEmailVerified.js
+++ b/functions/callableFunctions/ensureEmailVerified.js
@@ -1,0 +1,21 @@
+const admin = require('firebase-admin');
+const functions = require('firebase-functions');
+
+module.exports = functions.region('europe.west-2').https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
+  try {
+    const auth = admin.auth();
+    const uid = context.auth.uid;
+    const user = await auth.getUser(uid);
+    if (user.emailVerified === false) {
+      await auth.updateUser(uid, {
+        emailVerified: true,
+      });
+    }
+  } catch (e) {
+    throw new functions.https.HttpsError('unknown', e);
+  }
+  return {};
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -51,6 +51,8 @@ exports.exportApplicationCharacterIssues = require('./callableFunctions/exportAp
 exports.getUserEmailByID = require('./callableFunctions/getUserEmailByID');
 exports.updateEmailAddress = require('./callableFunctions/updateEmailAddress');
 
+exports.ensureEmailValidated = require('./callableFunctions/ensureEmailVerified');
+
 // exports.onExerciseUpdate_PublishVacancy = require('./exercises/onExerciseUpdate_PublishVacancy');
 // exports.onWriteVacancyStats = require('./exercises/onWriteVacancyStats');
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,12 @@
     "test:actions": "jest test/actions",
     "test:shared": "jest test/shared",
     "watch:test:rules": "mocha './test/rules/**/*.spec.js' --timeout=10000 --reporter=min --watch --watch-extensions=rules",
-    "ci:test:rules": "firebase emulators:exec --only firestore 'npm run test:rules'"
+    "ci:test:rules": "firebase emulators:exec --only firestore 'npm run test:rules'",
+    "db:export": "firestore-export -a ./service-account.json -b ./data/firestore.json",
+    "db:import": "firestore-import -a ./service-account.json -b ./data/firestore.json",
+    "db:emulator:export": "set \"FIRESTORE_EMULATOR_HOST=localhost:8282\" && npm run db:export",
+    "db:emulator:import": "set \"FIRESTORE_EMULATOR_HOST=localhost:8282\" && npm run db:import",
+    "firestore": "firebase emulators:start --only firestore --import=./data/ --export-on-exit=./data"
   },
   "dependencies": {
     "@google-cloud/storage": "^5.7.2",

--- a/test/rules/3.exercises.spec.js
+++ b/test/rules/3.exercises.spec.js
@@ -1,4 +1,4 @@
-const { setup, teardown, setupAdmin } = require('./helpers');
+const { setup, teardown, setupAdmin, getValidExerciseData } = require('./helpers');
 const { assertFails, assertSucceeds } = require('@firebase/rules-unit-testing');
 
 describe('Exercises', () => {
@@ -6,35 +6,45 @@ describe('Exercises', () => {
     await teardown();
   });
 
+  /**
+   * The following tests all require (if the auth validation is to be tested) to have valid field data.
+   * If valid field data isn't provided, these could fail on data validation, not on user authorisation.
+   */
+
   context('Create', () => {
     it('prevent un-authenticated user from creating an exercise', async () => {
       const db = await setup();
-      await assertFails(db.collection('exercises').add({}));
+      await assertFails(db.collection('exercises').add(getValidExerciseData()));
     });
 
     it('prevent authenticated user from creating an exercise', async () => {
       const db = await setup({ uid: 'user1', email: 'user@email.com', email_verified: false });
-      await assertFails(db.collection('exercises').add({}));
+      await assertFails(db.collection('exercises').add(getValidExerciseData()));
     });
 
     it('prevent authenticated user with verified email from creating an exercise', async () => {
       const db = await setup({ uid: 'user1', email: 'user@email.com', email_verified: true });
-      await assertFails(db.collection('exercises').add({}));
+      await assertFails(db.collection('exercises').add(getValidExerciseData()));
     });
 
     it('prevent authenticated user with un-verified JAC email from creating an exercise', async () => {
       const db = await setup({ uid: 'user1', email: 'user@judicialappointments.digital', email_verified: false });
+      await assertFails(db.collection('exercises').add(getValidExerciseData()));
+    });
+
+    it('prevent authenticated user with verified @judicialappointments.digital email to create an exercise with no data', async () => {
+      const db = await setup({ uid: 'user1', email: 'user@judicialappointments.digital', email_verified: true });
       await assertFails(db.collection('exercises').add({}));
     });
 
     it('allow authenticated user with verified @judicialappointments.digital email to create an exercise', async () => {
       const db = await setup({ uid: 'user1', email: 'user@judicialappointments.digital', email_verified: true });
-      await assertSucceeds(db.collection('exercises').add({}));
+      await assertSucceeds(db.collection('exercises').add(getValidExerciseData()));
     });
 
     it('allow authenticated user with verified @judicialappointments.gov.uk email to create an exercise', async () => {
       const db = await setup({ uid: 'user1', email: 'user@judicialappointments.gov.uk', email_verified: true });
-      await assertSucceeds(db.collection('exercises').add({}));
+      await assertSucceeds(db.collection('exercises').add(getValidExerciseData()));
     });
   });
 
@@ -74,7 +84,7 @@ describe('Exercises', () => {
     it('prevent un-authenticated user from updating an exercise', async () => {
       const db = await setup();
       await setupAdmin(db, { 'exercises/ex1': { } });
-      await assertFails(db.collection('exercises').doc('ex1').update({}));
+      await assertFails(db.collection('exercises').doc('ex1').update(getValidExerciseData()));
     });
 
     it('prevent authenticated user from updating an exercise', async () => {
@@ -82,7 +92,7 @@ describe('Exercises', () => {
         {  uid: 'user1', email: 'user@email.com', email_verified: false },
         { 'exercises/ex1': { } }
       );
-      await assertFails(db.collection('exercises').doc('ex1').update({}));
+      await assertFails(db.collection('exercises').doc('ex1').update(getValidExerciseData()));
     });
 
     it('prevent authenticated user with verified email from updating an exercise', async () => {
@@ -90,12 +100,20 @@ describe('Exercises', () => {
         {  uid: 'user1', email: 'user@email.com', email_verified: true },
         { 'exercises/ex1': { } }
       );
-      await assertFails(db.collection('exercises').doc('ex1').update({}));
+      await assertFails(db.collection('exercises').doc('ex1').update(getValidExerciseData()));
     });
 
     it('prevent authenticated user with un-verified JAC email from updating an exercise', async () => {
       const db = await setup(
         { uid: 'user1', email: 'user@judicialappointments.digital', email_verified: false },
+        { 'exercises/ex1': { } }
+      );
+      await assertFails(db.collection('exercises').doc('ex1').update(getValidExerciseData()));
+    });
+
+    it('prevent authenticated user with verified @judicialappointments.digital email to update an exercise with missing data', async () => {
+      const db = await setup(
+        { uid: 'user1', email: 'user@judicialappointments.digital', email_verified: true },
         { 'exercises/ex1': { } }
       );
       await assertFails(db.collection('exercises').doc('ex1').update({}));
@@ -106,7 +124,7 @@ describe('Exercises', () => {
         { uid: 'user1', email: 'user@judicialappointments.digital', email_verified: true },
         { 'exercises/ex1': { } }
       );
-      await assertSucceeds(db.collection('exercises').doc('ex1').update({}));
+      await assertSucceeds(db.collection('exercises').doc('ex1').update(getValidExerciseData()));
     });
 
     it('allow authenticated user with verified @judicialappointments.gov.uk email to update an exercise', async () => {
@@ -114,7 +132,7 @@ describe('Exercises', () => {
         { uid: 'user1', email: 'user@judicialappointments.gov.uk', email_verified: true },
         { 'exercises/ex1': { } }
       );
-      await assertSucceeds(db.collection('exercises').doc('ex1').update({}));
+      await assertSucceeds(db.collection('exercises').doc('ex1').update(getValidExerciseData()));
     });
   });
 

--- a/test/rules/helpers.js
+++ b/test/rules/helpers.js
@@ -53,5 +53,20 @@ module.exports.setupAdmin = async (db, data) => {
 };
 
 module.exports.getTimeStamp = (date) => {
-  return admin.firestore.Timestamp.fromDate(date);
+  return date.getTime();
+};
+
+const getRandomInt = (min, max) => {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min) + min); //The maximum is exclusive and the minimum is inclusive
+};
+
+module.exports.getValidExerciseData = () => {
+  return {
+    referenceNumber: '000' + getRandomInt(100, 1000),
+    progress: {started: true},
+    state: 'draft',
+    createdBy: 'user1',
+  };
 };


### PR DESCRIPTION
**Author checklist**

- [x] Include primary ticket number in title - e.g. "#123 New styling for widget" - and any additional tickets in description
- [x] Fill in the details below and delete as appropriate
- [x] Be proactive in getting your work approved 💪

---
## What's included?
This work fixes the email verification issue with third party (specifically Microsoft) authenticated accounts to the admin platform. The security rules require for all users that an email address is verified, and there is no way of telling on firestore where the request originated from.

Microsoft accounts do not set the email verified flag to true. It is a requirements that these are set to true if logging in via the admin platform, as users from the JAC and other government departments logging into the platform should not have to verify their email address.

This pull request is the other half connected with https://github.com/jac-uk/admin/pull/1476 and contains a re-instantiation of the email validation for security rules, fixes for some firestore rules, addition of field validation for some documents and fixing of all current firestore tests, as well as adding some new ones.



## Who should test?

- [ ] Product Owner
- [x] Developers
- [ ]  UTG

## How to test?

Login using a microsoft account once merged, as per https://github.com/jac-uk/admin/pull/1476. 

To run the tests, follow the instructions in the README.md file. You will need to change the file referenced in the package.json file for `npm run test:rules`

## Risk - how likely is this to impact other areas?

🟠 **Medium risk - this does change code that is shared with other areas**

## Additional context
Include screen grabs, video demo, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
