### PR TITLE
#636 Bugfix: Missing applicationRecords

### DIFF
--- a/functions/shared/factories.js
+++ b/functions/shared/factories.js
@@ -186,9 +186,9 @@ module.exports = (CONSTANTS) => {
   function newDiversityFlags(application) {
     const applicationData = application.equalityAndDiversitySurvey ? application.equalityAndDiversitySurvey : application;
     const data = {
-      gender: applicationData.gender,
+      gender: applicationData.gender || null,
       ethnicity: null,
-      disability: applicationData.disability,
+      disability: applicationData.disability || null,
       professionalBackground: {
         barrister: null,
         cilex: null,

--- a/nodeScripts/query.exercise-applications.js
+++ b/nodeScripts/query.exercise-applications.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const { app, db } = require('./shared/admin.js');
+// const { applyUpdates } = require('../functions/shared/helpers');
+
+const main = async () => {
+  const exerciseId = 'Yt04PxbBde5nfZxNgFWx';
+
+  const stats = {
+    applications: {},
+    applicationRecords: {},
+  };
+
+  const applications = await db.collection('applications').where('exerciseId', '==', exerciseId).select('status').get();
+  stats.applications.total = applications.docs.length;
+  applications.docs.forEach(doc => {
+    const application = doc.data();
+    if (stats.applications[application.status]) {
+      stats.applications[application.status]++;
+    } else {
+      stats.applications[application.status] = 1;
+    }
+  });
+
+  const applicationRecords = await db.collection('applicationRecords').where('exercise.id', '==', exerciseId).select('stage').get();
+  stats.applicationRecords.total = applicationRecords.docs.length;
+  applicationRecords.docs.forEach(doc => {
+    const applicationRecord = doc.data();
+    if (stats.applicationRecords[applicationRecord.stage]) {
+      stats.applicationRecords[applicationRecord.stage]++;
+    } else {
+      stats.applicationRecords[applicationRecord.stage] = 1;
+    }
+  });
+
+  const applicationIds = applications.docs.map(doc => doc.id);
+  const applicationRecordIds = applicationRecords.docs.map(doc => doc.id);
+  const appliedApplicationIds = applications.docs.filter(doc => doc.data().status === 'applied').map(doc => doc.id);
+
+  stats.orphanedApplications = applicationIds.filter(id => applicationRecordIds.indexOf(id) < 0).length;
+  stats.orphanedApplicationRecords = applicationRecordIds.filter(id => applicationIds.indexOf(id) < 0).length;
+  stats.orphanedAppliedApplicationIds = appliedApplicationIds.filter(id => applicationRecordIds.indexOf(id) < 0).length;  // remove `.length` to get IDs
+
+  return stats;
+};
+
+main()
+  .then((result) => {
+    console.log(result);
+    app.delete();
+    return process.exit();
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit();
+  });


### PR DESCRIPTION
Closes #636 

Fixes an issue where `applicationRecord` documents were not being created where the corresponding `application` document is missing **gender** or **disability** fields.

Also includes a node script to return some key stats/counts for an exercise and identify if there are any missing `applicationRecord` documents.