### PR TITLE
#643 Bugfix: search not working for new candidates

### DIFF
--- a/functions/actions/candidates/personalDetails/onCreate.js
+++ b/functions/actions/candidates/personalDetails/onCreate.js
@@ -1,0 +1,17 @@
+module.exports = (config, firebase, db) => {
+  const { updateCandidate } = require('../search')(firebase, db);
+
+  return onCreate;
+
+  /**
+   * Candidate Personal Details event handler for Create
+   */
+  async function onCreate(candidateId, dataBefore, dataAfter) {
+
+    // update candidate document
+    const result = await updateCandidate(candidateId);
+
+    return result;
+  }
+
+};

--- a/functions/actions/candidates/search.js
+++ b/functions/actions/candidates/search.js
@@ -75,8 +75,8 @@ module.exports = (firebase, db) => {
       const applicationsMap = {};
       const referenceNumbers = [];
       applications.forEach(application => {
-        exercisesMap[application.exerciseId] = application.status;
-        applicationsMap[application.id] = application.status;
+        exercisesMap[application.exerciseId] = application.status ? application.status : 'draft';
+        applicationsMap[application.id] = application.status ? application.status : 'draft';
         if (application.referenceNumber) { referenceNumbers.push(application.referenceNumber); }
       });
       candidateData[candidates[i].id].exercisesMap = exercisesMap;

--- a/functions/backgroundFunctions/onCandidatePersonalDetailsCreate.js
+++ b/functions/backgroundFunctions/onCandidatePersonalDetailsCreate.js
@@ -1,0 +1,12 @@
+const functions = require('firebase-functions');
+const config = require('../shared/config');
+const { firebase, db } = require('../shared/admin');
+const onCandidatePersonalDetailsCreate = require('../actions/candidates/personalDetails/onCreate')(config, firebase, db);
+
+module.exports = functions.region('europe-west2').firestore
+  .document('candidates/{candidateId}/documents/personalDetails')
+  .onCreate((document, context) => {
+    const candidateId = context.params.candidateId;
+    const data = document.data();
+    return onCandidatePersonalDetailsCreate(candidateId, data);
+  });

--- a/functions/index.js
+++ b/functions/index.js
@@ -15,6 +15,7 @@ exports.onApplicationRecordUpdate = require('./backgroundFunctions/onApplication
 exports.onQualifyingTestResponseUpdate = require('./backgroundFunctions/onQualifyingTestResponseUpdate');
 exports.onPanelUpdate = require('./backgroundFunctions/onPanelUpdate');
 exports.onDocumentUploaded = require('./backgroundFunctions/onDocumentUploaded');
+exports.onCandidatePersonalDetailsCreate = require('./backgroundFunctions/onCandidatePersonalDetailsCreate');
 exports.onCandidatePersonalDetailsUpdate = require('./backgroundFunctions/onCandidatePersonalDetailsUpdate');
 
 // Callable


### PR DESCRIPTION
Closes #643 

In short, we were updating the candidate search meta data when `personalDetails` were updated but not when `personalDetails` were first created