### PR TITLE
admin #1498 - add EMP records to diversity report

### DIFF
--- a/nodeScripts/generateDiversityReport.js
+++ b/nodeScripts/generateDiversityReport.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const { firebase, app, db } = require('./shared/admin.js');
+const { generateDiversityReport } = require('../functions/actions/exercises/generateDiversityReport')(firebase, db);
+
+const main = async () => {
+  return generateDiversityReport('wdpALbyICL7ZxxN5AQt8');
+};
+
+main()
+  .then((result) => {
+    console.table(result);
+    app.delete();
+    return process.exit();
+  })
+  .catch((error) => {
+    console.error('error', error);
+    process.exit();
+  });


### PR DESCRIPTION
## What's included?
The last lines on 1498 - _I would suggest this data is best added to the exercise data export used by the statisticians when compiling the official statistics._ - is in reference to the diversity report.
Following the pattern for other stats, i have added emp to each stage of the diversity report, think it slots straight in. 

Ideally if this is merged before the admin ticket, which enables 'gender' and 'ethnicity' flags for emp, then the report download functionality can be e2e tested by the UTG via the platform.

## Who should test?
✅ Developers

## How to test?
I have added a nodeScript if you want to test this locally. 

## Risk - how likely is this to impact other areas?
🟠 Medium risk - lets hope this doesn't break the report downloads.
