### PR TITLE
#672 - Custom report- Data Issues on Live Platform

### DIFF
--- a/JAC - Digital Platform.postman_collection.json
+++ b/JAC - Digital Platform.postman_collection.json
@@ -779,6 +779,43 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Custom Report",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"data\": {\r\n        \"exerciseId\": \"kJKbG9TOQToEzB4AlEV1\",\r\n        \"columns\": [\r\n            \"personalDetails.fullName\",\r\n            \"locationPreferences\",\r\n            \"jurisdictionPreferences\",\r\n            \"qualifications\"\r\n        ],\r\n        \"type\": \"showData\",\r\n        \"whereClauses\": []\r\n    }\r\n}"
+						},
+						"url": {
+							"raw": "{{host}}/getApplicationData",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"getApplicationData"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		}

--- a/functions/actions/exercises/getApplicationData.js
+++ b/functions/actions/exercises/getApplicationData.js
@@ -30,10 +30,8 @@ module.exports = (config, firebase, db, auth) => {
           record[column] = '(blank)';
         }
 
-
         // Handle array values
         if(_.isArray(record[column])) {
-
           let formattedArray = '';
           for (const arrayItem of record[column]) {
             const arrayValuePaths = getArrayValuePath(column);
@@ -41,11 +39,15 @@ module.exports = (config, firebase, db, auth) => {
               for (const arrayValuePath of arrayValuePaths) {
                 formattedArray += _.get(arrayItem, arrayValuePath, '(blank)') + ' - ';
               }
-              //remove last ', ' from string
+              // remove the last ' - ' from string
               formattedArray = formattedArray.substring(0, formattedArray.length - 3);
-              formattedArray += '; ';
+            } else {
+              formattedArray += arrayItem ? arrayItem : '(blank)';
             }
+            formattedArray += ', ';
           }
+
+          // remove the last ', ' from string
           formattedArray = formattedArray.substring(0, formattedArray.length - 2);
 
           // if something went wrong with parsing the array, just return true
@@ -54,7 +56,6 @@ module.exports = (config, firebase, db, auth) => {
           } else {
             record[column] = formattedArray;
           }
-
         }
 
         // Handle time values


### PR DESCRIPTION
Problem:

When using the custom report for some exercises, it returns (blank) for location preferences and jurisdiction preferences even when there is data available in the database.

Cause: 

There was a bug in the `getApplicationData` function where it would return (blank) for 1-dimentional arrays even if it contained data.

Testing:

- Simple strings:
  - Find an application that has location or/and jurisdictions preferences that accepts simple strings values (no arrays)
  - Create a custom report and check that location or/and jurisdictions preferences display correctly.
- 1-dimensional arrays:
  - Find an application that has location or/and jurisdictions preferences that accepts multiple choices in the form checkboxes
  - Create a custom report and check that location or/and jurisdictions preferences display correctly.
- Multi-dimensional arrays:
  - Find an application that has an application with more than 1 qualification listed
  - Create a custom report and check that applicants multiple qualifications display correctly.

Here is a sample of the data that was fetched when executing `getApplicationData` using Postman:

[Criteria]
```
{
    "data": {
        "exerciseId": "kJKbG9TOQToEzB4AlEV1",
        "columns": [
            "personalDetails.fullName",
            "locationPreferences",
            "jurisdictionPreferences",
            "qualifications"
        ],
        "type": "showData",
        "whereClauses": []
    }
}
```

[Response]
```
{
    "result": [
        {
            "personalDetails.fullName": "Monika Szczygieł",
            "locationPreferences": "London",
            "jurisdictionPreferences": "(blank)",
            "qualifications": "barrister - england-wales"
        },
        {
            "personalDetails.fullName": "Monika Szczygieł",
            "locationPreferences": "London",
            "jurisdictionPreferences": "(blank)",
            "qualifications": "barrister - england-wales"
        },
        {
            "personalDetails.fullName": "Claire Troughton",
            "locationPreferences": "(blank)",
            "jurisdictionPreferences": "(blank)",
            "qualifications": "(blank)"
        },
        {
            "personalDetails.fullName": "Enor Anidi-Ryz",
            "locationPreferences": "London",
            "jurisdictionPreferences": "choice 1, choice 2",
            "qualifications": "barrister - england-wales, barrister - northern-ireland"
        }
    ]
}
```

[Monika test Exercise - Custom report]
![image](https://user-images.githubusercontent.com/79906532/149955344-f0c6722c-2182-4865-a254-94c82a700f7c.png)
