### PR TITLE
Hotfix. Reasonable adjustment details should be optional

### DIFF
--- a/functions/shared/factories.js
+++ b/functions/shared/factories.js
@@ -286,7 +286,7 @@ module.exports = (CONSTANTS) => {
     if (application.personalDetails) {
       applicationRecord.candidate.fullName = application.personalDetails.fullName;
       applicationRecord.candidate.reasonableAdjustments = application.personalDetails.reasonableAdjustments;
-      applicationRecord.candidate.reasonableAdjustmentsDetails = application.personalDetails.reasonableAdjustmentsDetails;
+      applicationRecord.candidate.reasonableAdjustmentsDetails = application.personalDetails.reasonableAdjustments && application.personalDetails.reasonableAdjustmentsDetails ? application.personalDetails.reasonableAdjustmentsDetails : null;
       applicationRecord.flags.reasonableAdjustments = application.personalDetails.reasonableAdjustments;
     }
     return applicationRecord;


### PR DESCRIPTION
Ensures that the creation of `applicationRecords` does not rely on `reasonableAdjustmentDetails` existing in the corresponding `applications`.

Also only copies across `reasonableAdjustmentDetails` if the related `reasonableAdjustments` field is `true`. 