### PR TITLE
Character issues. Use correct application version

### DIFF
--- a/functions/actions/applications/flagApplicationIssues.js
+++ b/functions/actions/applications/flagApplicationIssues.js
@@ -36,7 +36,7 @@ module.exports = (config, db) => {
 
     // check for eligibility issues and update document
     const eligibilityIssues = getEligibilityIssues(exercise, application);
-    const characterIssues = getCharacterIssues(application);
+    const characterIssues = getCharacterIssues(exercise, application);
     const data = {};
     data['processing.flags.eligibilityIssues'] = eligibilityIssues && eligibilityIssues.length > 0;
     data['processing.eligibilityIssues'] = eligibilityIssues;
@@ -210,12 +210,12 @@ module.exports = (config, db) => {
     return issues;
   }
 
-  function getCharacterIssues(application) {
+  function getCharacterIssues(exercise, application) {
 
     let questions;
     let answers;
 
-    if (application.characterInformationV2) {
+    if (exercise._applicationVersion >= 2) {
       questions = config.APPLICATION.CHARACTER_ISSUES_V2;
       answers = application.characterInformationV2;
     } else if (application.characterInformation) {
@@ -225,7 +225,7 @@ module.exports = (config, db) => {
 
     const issues = [];
 
-    if (questions) {
+    if (questions && answers) {
       Object.keys(questions).forEach(key => {
         if (answers[key]) {
           const summary = questions[key].summary;

--- a/functions/actions/applications/flagApplicationIssues.js
+++ b/functions/actions/applications/flagApplicationIssues.js
@@ -72,7 +72,7 @@ module.exports = (config, db) => {
     const commands = [];
     for (let i = 0, len = applications.length; i < len; ++i) {
       const eligibilityIssues = getEligibilityIssues(exercise, applications[i]);
-      const characterIssues = getCharacterIssues(applications[i]);
+      const characterIssues = getCharacterIssues(exercise, applications[i]);
 
       const data = {};
       if (eligibilityIssues && eligibilityIssues.length > 0) {


### PR DESCRIPTION
Some application issues were being excluded from the Character Issues report.

This fix ensures we are looking at the `exercise._applicationVersion` field in order to decide where to search for character issues.

Previously the report was looking at  the existence of `application.characterInformation` and `application.characterInformationV2`.

@tomlovesgithub @HalcyonJAC please do test this thoroughly to ensure the correct `characterInformation*` field is searched, based on how the exercise has been configured - i.e. which `_applicationVersion` has been selected.