### PR TITLE
Fix: Event Logger

### DIFF
--- a/functions/actions/applicationRecords.js
+++ b/functions/actions/applicationRecords.js
@@ -1,9 +1,9 @@
 const { getDocument, getDocuments, applyUpdates } = require('../shared/helpers');
 
-module.exports = (config, firebase, db) => {
+module.exports = (config, auth, firebase, db) => {
   const { newApplicationRecord } = require('../shared/factories')(config);
   const newQualifyingTestResponse = require('../shared/factories/QualifyingTests/newQualifyingTestResponse')(config, firebase);
-  const { logEvent } = require('./logs/logEvent')(firebase, db);
+  const { logEvent } = require('./logs/logEvent')(auth, firebase, db);
   const { refreshApplicationCounts } = require('../actions/exercises/refreshApplicationCounts')(firebase, db);
 
   return {

--- a/functions/actions/applicationRecords.js
+++ b/functions/actions/applicationRecords.js
@@ -1,9 +1,9 @@
 const { getDocument, getDocuments, applyUpdates } = require('../shared/helpers');
 
-module.exports = (config, auth, firebase, db) => {
+module.exports = (config, firebase, db, auth) => {
   const { newApplicationRecord } = require('../shared/factories')(config);
   const newQualifyingTestResponse = require('../shared/factories/QualifyingTests/newQualifyingTestResponse')(config, firebase);
-  const { logEvent } = require('./logs/logEvent')(auth, firebase, db);
+  const { logEvent } = require('./logs/logEvent')(firebase, db, auth);
   const { refreshApplicationCounts } = require('../actions/exercises/refreshApplicationCounts')(firebase, db);
 
   return {

--- a/functions/actions/applications/applications.js
+++ b/functions/actions/applications/applications.js
@@ -3,8 +3,8 @@ const { getAllDocuments, applyUpdates, getDocument, getDocuments } = require('..
 
 const testApplicationsFileName = 'test_applications.json';
 
-module.exports = (config, firebase, db) => {
-  const { initialiseApplicationRecords } = require('../../actions/applicationRecords')(config, firebase, db);
+module.exports = (config, firebase, db, auth) => {
+  const { initialiseApplicationRecords } = require('../../actions/applicationRecords')(config, firebase, db, auth);
   const { refreshApplicationCounts } = require('../../actions/exercises/refreshApplicationCounts')(firebase, db);
   const { newNotificationCharacterCheckRequest } = require('../../shared/factories')(config);
   const slack = require('../../shared/slack')(config);
@@ -138,12 +138,12 @@ module.exports = (config, firebase, db) => {
   }
 
   /**
-    * load test applications JSON file from cloud storage 
+    * load test applications JSON file from cloud storage
     */
   async function loadTestApplications() {
     const bucket = firebase.storage().bucket(config.STORAGE_URL);
     const file = bucket.file(testApplicationsFileName);
-    
+
     try {
       const data = await file.download();
       return JSON.parse(data[0]);
@@ -154,17 +154,17 @@ module.exports = (config, firebase, db) => {
 
   /**
    * Create test applications
-   * 
+   *
    * @param {string} exerciseId
    * @param {number} noOfTestApplications
    * @param {array} testApplications
-   * 
+   *
    * @return {object}
-   * 
+   *
    */
   async function createTestApplications(data) {
     const { exerciseId, noOfTestApplications, testApplications } = data;
-    
+
     // format test applications with exercise information
     const exercise = await getDocument(db.collection('exercises').doc(exerciseId));
     const applications = [];
@@ -189,7 +189,7 @@ module.exports = (config, firebase, db) => {
 
     // create applications
     let resCreateApplications = await createApplications(applications);
-    
+
     // initialise application records
     initialiseApplicationRecords({ exerciseId: exercise.id });
 
@@ -202,10 +202,10 @@ module.exports = (config, firebase, db) => {
 
   /**
    * Delete applications
-   * 
+   *
    * @param {string} exerciseId
-   * 
-   * @return {object} 
+   *
+   * @return {object}
    */
    async function deleteApplications(exerciseId) {
     let documentsRef;
@@ -216,7 +216,7 @@ module.exports = (config, firebase, db) => {
 
     let noOfDeletedApplications = 0;
     let noOfDeletedApplicationRecords = 0;
-    
+
     // fetch existing application records
     documentsRef = db.collection('applicationRecords').where('exercise.id', '==', exerciseId);
     documents = await getDocuments(documentsRef);

--- a/functions/actions/logs/logEvent.js
+++ b/functions/actions/logs/logEvent.js
@@ -1,6 +1,5 @@
-const { auth } = require('../../shared/admin.js');
 
-module.exports = (firebase, db) => {
+module.exports = (auth, firebase, db) => {
   return {
     logEvent,
   };

--- a/functions/actions/logs/logEvent.js
+++ b/functions/actions/logs/logEvent.js
@@ -1,5 +1,5 @@
 
-module.exports = (auth, firebase, db) => {
+module.exports = (firebase, db, auth) => {
   return {
     logEvent,
   };

--- a/functions/backgroundFunctions/onApplicationCreate.js
+++ b/functions/backgroundFunctions/onApplicationCreate.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 const config = require('../shared/config');
-const { auth, firebase, db } = require('../shared/admin');
-const { onApplicationCreate } = require('../actions/applications/applications')(config, firebase, db);
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { firebase, db, auth } = require('../shared/admin');
+const { onApplicationCreate } = require('../actions/applications/applications')(config, firebase, db, auth);
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 
 module.exports = functions.region('europe-west2').firestore
   .document('applications/{applicationId}')

--- a/functions/backgroundFunctions/onApplicationCreate.js
+++ b/functions/backgroundFunctions/onApplicationCreate.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 const config = require('../shared/config');
-const { firebase, db } = require('../shared/admin');
+const { auth, firebase, db } = require('../shared/admin');
 const { onApplicationCreate } = require('../actions/applications/applications')(config, firebase, db);
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 
 module.exports = functions.region('europe-west2').firestore
   .document('applications/{applicationId}')

--- a/functions/backgroundFunctions/onApplicationRecordCreate.js
+++ b/functions/backgroundFunctions/onApplicationRecordCreate.js
@@ -1,7 +1,7 @@
 const functions = require('firebase-functions');
 const config = require('../shared/config');
-const { auth, firebase, db } = require('../shared/admin');
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { firebase, db, auth } = require('../shared/admin');
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 
 module.exports = functions.region('europe-west2').firestore
   .document('applicationRecords/{applicationRecordId}')

--- a/functions/backgroundFunctions/onApplicationRecordCreate.js
+++ b/functions/backgroundFunctions/onApplicationRecordCreate.js
@@ -1,7 +1,7 @@
 const functions = require('firebase-functions');
 const config = require('../shared/config');
-const { firebase, db } = require('../shared/admin');
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { auth, firebase, db } = require('../shared/admin');
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 
 module.exports = functions.region('europe-west2').firestore
   .document('applicationRecords/{applicationRecordId}')

--- a/functions/backgroundFunctions/onApplicationRecordUpdate.js
+++ b/functions/backgroundFunctions/onApplicationRecordUpdate.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 const config = require('../shared/config');
-const { auth, firebase, db } = require('../shared/admin.js');
-const { onApplicationRecordUpdate } = require('../actions/applicationRecords')(config, auth, firebase, db);
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { firebase, db, auth } = require('../shared/admin.js');
+const { onApplicationRecordUpdate } = require('../actions/applicationRecords')(config, firebase, db, auth);
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 
 module.exports = functions.region('europe-west2').firestore
   .document('applicationRecords/{applicationRecordId}')

--- a/functions/backgroundFunctions/onApplicationRecordUpdate.js
+++ b/functions/backgroundFunctions/onApplicationRecordUpdate.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 const config = require('../shared/config');
-const { firebase, db } = require('../shared/admin.js');
-const { onApplicationRecordUpdate } = require('../actions/applicationRecords')(config, firebase, db);
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { auth, firebase, db } = require('../shared/admin.js');
+const { onApplicationRecordUpdate } = require('../actions/applicationRecords')(config, auth, firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 
 module.exports = functions.region('europe-west2').firestore
   .document('applicationRecords/{applicationRecordId}')

--- a/functions/backgroundFunctions/onApplicationUpdate.js
+++ b/functions/backgroundFunctions/onApplicationUpdate.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 const config = require('../shared/config');
-const { firebase, db } = require('../shared/admin');
+const { auth, firebase, db } = require('../shared/admin');
 const onApplicationUpdate = require('../actions/applications/onUpdate')(config, firebase, db);
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 
 module.exports = functions.region('europe-west2').firestore
   .document('applications/{applicationId}')

--- a/functions/backgroundFunctions/onApplicationUpdate.js
+++ b/functions/backgroundFunctions/onApplicationUpdate.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 const config = require('../shared/config');
-const { auth, firebase, db } = require('../shared/admin');
+const { firebase, db, auth } = require('../shared/admin');
 const onApplicationUpdate = require('../actions/applications/onUpdate')(config, firebase, db);
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 
 module.exports = functions.region('europe-west2').firestore
   .document('applications/{applicationId}')

--- a/functions/backgroundFunctions/onDelete.js
+++ b/functions/backgroundFunctions/onDelete.js
@@ -1,6 +1,6 @@
 const functions = require('firebase-functions');
-const { firebase, db } = require('../shared/admin');
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { auth, firebase, db } = require('../shared/admin');
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 
 // This function is triggered when records are deleted in firestore.
 // The purpose is to archive, not delete data from the database.

--- a/functions/backgroundFunctions/onDelete.js
+++ b/functions/backgroundFunctions/onDelete.js
@@ -1,6 +1,6 @@
 const functions = require('firebase-functions');
-const { auth, firebase, db } = require('../shared/admin');
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { firebase, db, auth } = require('../shared/admin');
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 
 // This function is triggered when records are deleted in firestore.
 // The purpose is to archive, not delete data from the database.

--- a/functions/callableFunctions/createTestApplications.js
+++ b/functions/callableFunctions/createTestApplications.js
@@ -29,7 +29,7 @@ module.exports = functions.runWith(runtimeOptions).region('europe-west2').https.
   if (!testApplications) {
     throw new functions.https.HttpsError('failed-precondition', `Failed to load test applications from cloud storage (${fileName}).`);
   }
-  
+
   const maxNoOfTestApplications = testApplications.length;
   if (data.noOfTestApplications < 1 || data.noOfTestApplications > maxNoOfTestApplications) {
     throw new functions.https.HttpsError('invalid-argument', 'The number of test applications should be between 1 and ' + maxNoOfTestApplications);

--- a/functions/callableFunctions/createTestUsers.js
+++ b/functions/callableFunctions/createTestUsers.js
@@ -29,7 +29,7 @@ module.exports = functions.runWith(runtimeOptions).region('europe-west2').https.
   if (!testApplications) {
     throw new functions.https.HttpsError('failed-precondition', `Failed to load test applications from cloud storage (${fileName}).`);
   }
-  
+
   const maxNoOfTestApplications = testApplications.length;
   if (data.noOfTestUsers < 1 || data.noOfTestUsers > maxNoOfTestApplications) {
     throw new functions.https.HttpsError('invalid-argument', 'The number of test applications should be between 1 and ' + maxNoOfTestApplications);

--- a/functions/callableFunctions/deleteTestUsers.js
+++ b/functions/callableFunctions/deleteTestUsers.js
@@ -27,7 +27,7 @@ module.exports = functions.runWith(runtimeOptions).region('europe-west2').https.
   if (!testApplications) {
     throw new functions.https.HttpsError('failed-precondition', `Failed to load test applications from cloud storage (${fileName}).`);
   }
-  
+
   const maxNoOfTestApplications = testApplications.length;
   if (data.noOfTestUsers < 1 || data.noOfTestUsers > maxNoOfTestApplications) {
     throw new functions.https.HttpsError('invalid-argument', 'The number of test applications should be between 1 and ' + maxNoOfTestApplications);

--- a/functions/callableFunctions/exportApplicationCharacterIssues.js
+++ b/functions/callableFunctions/exportApplicationCharacterIssues.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 const {getDocument} = require('../shared/helpers');
-const { auth, firebase, db } = require('../shared/admin.js');
+const { firebase, db, auth } = require('../shared/admin.js');
 const { exportApplicationCharacterIssues } = require('../actions/exercises/exportApplicationCharacterIssues')(firebase, db);
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/exportApplicationCharacterIssues.js
+++ b/functions/callableFunctions/exportApplicationCharacterIssues.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 const {getDocument} = require('../shared/helpers');
-const { firebase, db } = require('../shared/admin.js');
+const { auth, firebase, db } = require('../shared/admin.js');
 const { exportApplicationCharacterIssues } = require('../actions/exercises/exportApplicationCharacterIssues')(firebase, db);
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/exportApplicationContactsData.js
+++ b/functions/callableFunctions/exportApplicationContactsData.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
-const { auth, firebase, db } = require('../shared/admin.js');
+const { firebase, db, auth } = require('../shared/admin.js');
 const { exportApplicationContactsData } = require('../actions/exercises/exportApplicationContactsData')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/exportApplicationContactsData.js
+++ b/functions/callableFunctions/exportApplicationContactsData.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
-const { firebase, db } = require('../shared/admin.js');
+const { auth, firebase, db } = require('../shared/admin.js');
 const { exportApplicationContactsData } = require('../actions/exercises/exportApplicationContactsData')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/exportApplicationEligibilityIssues.js
+++ b/functions/callableFunctions/exportApplicationEligibilityIssues.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
-const { firebase, db } = require('../shared/admin.js');
+const { auth, firebase, db } = require('../shared/admin.js');
 const { exportApplicationEligibilityIssues } = require('../actions/exercises/exportApplicationEligibilityIssues')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/exportApplicationEligibilityIssues.js
+++ b/functions/callableFunctions/exportApplicationEligibilityIssues.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
-const { auth, firebase, db } = require('../shared/admin.js');
+const { firebase, db, auth } = require('../shared/admin.js');
 const { exportApplicationEligibilityIssues } = require('../actions/exercises/exportApplicationEligibilityIssues')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/exportExerciseData.js
+++ b/functions/callableFunctions/exportExerciseData.js
@@ -1,10 +1,10 @@
 const functions = require('firebase-functions');
 const { checkArguments } = require('../shared/helpers.js');
 const config = require('../shared/config');
-const { firebase, db } = require('../shared/admin.js');
+const { auth, firebase, db } = require('../shared/admin.js');
 const { exportExerciseData } = require('../actions/exercises/exportExerciseData')(config, firebase, db);
 const { getAllDocuments } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 const runtimeOptions = {

--- a/functions/callableFunctions/exportExerciseData.js
+++ b/functions/callableFunctions/exportExerciseData.js
@@ -1,10 +1,10 @@
 const functions = require('firebase-functions');
 const { checkArguments } = require('../shared/helpers.js');
 const config = require('../shared/config');
-const { auth, firebase, db } = require('../shared/admin.js');
+const { firebase, db, auth } = require('../shared/admin.js');
 const { exportExerciseData } = require('../actions/exercises/exportExerciseData')(config, firebase, db);
 const { getAllDocuments } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 const runtimeOptions = {

--- a/functions/callableFunctions/exportQualifyingTestResponses.js
+++ b/functions/callableFunctions/exportQualifyingTestResponses.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
-const { firebase, db } = require('../shared/admin.js');
+const { auth, firebase, db } = require('../shared/admin.js');
 const { exportQualifyingTestResponses } = require('../actions/qualifyingTestResponses/export')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/exportQualifyingTestResponses.js
+++ b/functions/callableFunctions/exportQualifyingTestResponses.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
-const { auth, firebase, db } = require('../shared/admin.js');
+const { firebase, db, auth } = require('../shared/admin.js');
 const { exportQualifyingTestResponses } = require('../actions/qualifyingTestResponses/export')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/generateAgencyReport.js
+++ b/functions/callableFunctions/generateAgencyReport.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
-const { firebase, db } = require('../shared/admin.js');
+const { auth, firebase, db } = require('../shared/admin.js');
 const { generateAgencyReport } = require('../actions/exercises/generateAgencyReport')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/generateAgencyReport.js
+++ b/functions/callableFunctions/generateAgencyReport.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
-const { auth, firebase, db } = require('../shared/admin.js');
+const { firebase, db, auth } = require('../shared/admin.js');
 const { generateAgencyReport } = require('../actions/exercises/generateAgencyReport')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/generateDiversityReport.js
+++ b/functions/callableFunctions/generateDiversityReport.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
-const { firebase, db } = require('../shared/admin.js');
+const { auth, firebase, db } = require('../shared/admin.js');
 const { generateDiversityReport } = require('../actions/exercises/generateDiversityReport')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/generateDiversityReport.js
+++ b/functions/callableFunctions/generateDiversityReport.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
-const { auth, firebase, db } = require('../shared/admin.js');
+const { firebase, db, auth } = require('../shared/admin.js');
 const { generateDiversityReport } = require('../actions/exercises/generateDiversityReport')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/generateHandoverReport.js
+++ b/functions/callableFunctions/generateHandoverReport.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
-const { firebase, db } = require('../shared/admin.js');
+const { auth, firebase, db } = require('../shared/admin.js');
 const { generateHandoverReport } = require('../actions/exercises/generateHandoverReport')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/generateHandoverReport.js
+++ b/functions/callableFunctions/generateHandoverReport.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
-const { auth, firebase, db } = require('../shared/admin.js');
+const { firebase, db, auth } = require('../shared/admin.js');
 const { generateHandoverReport } = require('../actions/exercises/generateHandoverReport')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/generateOutreachReport.js
+++ b/functions/callableFunctions/generateOutreachReport.js
@@ -1,9 +1,9 @@
 const functions = require('firebase-functions');
-const { firebase, db } = require('../shared/admin.js');
+const { auth, firebase, db } = require('../shared/admin.js');
 const { checkArguments } = require('../shared/helpers.js');
 const { generateOutreachReport } = require('../actions/exercises/generateOutreachReport')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/generateOutreachReport.js
+++ b/functions/callableFunctions/generateOutreachReport.js
@@ -1,9 +1,9 @@
 const functions = require('firebase-functions');
-const { auth, firebase, db } = require('../shared/admin.js');
+const { firebase, db, auth } = require('../shared/admin.js');
 const { checkArguments } = require('../shared/helpers.js');
 const { generateOutreachReport } = require('../actions/exercises/generateOutreachReport')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/generateQualifyingTestReport.js
+++ b/functions/callableFunctions/generateQualifyingTestReport.js
@@ -1,10 +1,10 @@
 const functions = require('firebase-functions');
 const { checkArguments } = require('../shared/helpers.js');
 const config = require('../shared/config');
-const { firebase, db } = require('../shared/admin.js');
+const { auth, firebase, db } = require('../shared/admin.js');
 const { generateQualifyingTestReport } = require('../actions/qualifyingTests/generateQualifyingTestReport')(config, firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/generateQualifyingTestReport.js
+++ b/functions/callableFunctions/generateQualifyingTestReport.js
@@ -1,10 +1,10 @@
 const functions = require('firebase-functions');
 const { checkArguments } = require('../shared/helpers.js');
 const config = require('../shared/config');
-const { auth, firebase, db } = require('../shared/admin.js');
+const { firebase, db, auth } = require('../shared/admin.js');
 const { generateQualifyingTestReport } = require('../actions/qualifyingTests/generateQualifyingTestReport')(config, firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/generateReasonableAdjustmentsReport.js
+++ b/functions/callableFunctions/generateReasonableAdjustmentsReport.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
-const { firebase, db } = require('../shared/admin.js');
+const { auth, firebase, db } = require('../shared/admin.js');
 const { generateReasonableAdjustmentsReport } = require('../actions/exercises/generateReasonableAdjustmentsReport')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/generateReasonableAdjustmentsReport.js
+++ b/functions/callableFunctions/generateReasonableAdjustmentsReport.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
-const { auth, firebase, db } = require('../shared/admin.js');
+const { firebase, db, auth } = require('../shared/admin.js');
 const { generateReasonableAdjustmentsReport } = require('../actions/exercises/generateReasonableAdjustmentsReport')(firebase, db);
 const { getDocument } = require('../shared/helpers');
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/initialiseApplicationRecords.js
+++ b/functions/callableFunctions/initialiseApplicationRecords.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 const config = require('../shared/config');
-const { firebase, db } = require('../shared/admin.js');
+const { auth, firebase, db } = require('../shared/admin.js');
 const { checkArguments } = require('../shared/helpers.js');
-const { initialiseApplicationRecords } = require('../actions/applicationRecords')(config, firebase, db);
+const { initialiseApplicationRecords } = require('../actions/applicationRecords')(config, auth, firebase, db);
 const { generateDiversityReport } = require('../actions/exercises/generateDiversityReport')(firebase, db);
 // const { flagApplicationIssuesForExercise } = require('../actions/applications/flagApplicationIssues')(config, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);

--- a/functions/callableFunctions/initialiseApplicationRecords.js
+++ b/functions/callableFunctions/initialiseApplicationRecords.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 const config = require('../shared/config');
-const { auth, firebase, db } = require('../shared/admin.js');
+const { firebase, db, auth } = require('../shared/admin.js');
 const { checkArguments } = require('../shared/helpers.js');
-const { initialiseApplicationRecords } = require('../actions/applicationRecords')(config, auth, firebase, db);
+const { initialiseApplicationRecords } = require('../actions/applicationRecords')(config, firebase, db, auth);
 const { generateDiversityReport } = require('../actions/exercises/generateDiversityReport')(firebase, db);
 // const { flagApplicationIssuesForExercise } = require('../actions/applications/flagApplicationIssues')(config, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);

--- a/functions/callableFunctions/initialiseMissingApplicationRecords.js
+++ b/functions/callableFunctions/initialiseMissingApplicationRecords.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 const config = require('../shared/config');
-const { firebase, db } = require('../shared/admin.js');
+const { auth, firebase, db } = require('../shared/admin.js');
 const { checkArguments } = require('../shared/helpers.js');
-const { initialiseMissingApplicationRecords } = require('../actions/applicationRecords')(config, firebase, db);
+const { initialiseMissingApplicationRecords } = require('../actions/applicationRecords')(config, auth, firebase, db);
 const { generateDiversityReport } = require('../actions/exercises/generateDiversityReport')(firebase, db);
 // const { flagApplicationIssuesForExercise } = require('../actions/applications/flagApplicationIssues')(config, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);

--- a/functions/callableFunctions/initialiseMissingApplicationRecords.js
+++ b/functions/callableFunctions/initialiseMissingApplicationRecords.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 const config = require('../shared/config');
-const { auth, firebase, db } = require('../shared/admin.js');
+const { firebase, db, auth } = require('../shared/admin.js');
 const { checkArguments } = require('../shared/helpers.js');
-const { initialiseMissingApplicationRecords } = require('../actions/applicationRecords')(config, auth, firebase, db);
+const { initialiseMissingApplicationRecords } = require('../actions/applicationRecords')(config, firebase, db, auth);
 const { generateDiversityReport } = require('../actions/exercises/generateDiversityReport')(firebase, db);
 // const { flagApplicationIssuesForExercise } = require('../actions/applications/flagApplicationIssues')(config, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);

--- a/functions/callableFunctions/logEvent.js
+++ b/functions/callableFunctions/logEvent.js
@@ -1,6 +1,6 @@
 const functions = require('firebase-functions');
-const { firebase, db } = require('../shared/admin.js');
-const { logEvent } = require('../actions/logs/logEvent')(firebase, db);
+const { auth, firebase, db } = require('../shared/admin.js');
+const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/logEvent.js
+++ b/functions/callableFunctions/logEvent.js
@@ -1,6 +1,6 @@
 const functions = require('firebase-functions');
-const { auth, firebase, db } = require('../shared/admin.js');
-const { logEvent } = require('../actions/logs/logEvent')(auth, firebase, db);
+const { firebase, db, auth } = require('../shared/admin.js');
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/functions/callableFunctions/sendCharacterCheckRequests.js
+++ b/functions/callableFunctions/sendCharacterCheckRequests.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 const config = require('../shared/config');
-const { firebase, db } = require('../shared/admin.js');
+const { firebase, db, auth } = require('../shared/admin.js');
 const { checkArguments } = require('../shared/helpers.js');
-const { sendCharacterCheckRequests } = require('../actions/applications/applications')(config, firebase, db);
+const { sendCharacterCheckRequests } = require('../actions/applications/applications')(config, firebase, db, auth);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 
 module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {

--- a/nodeScripts/capacityTest_initialiseQTs.js
+++ b/nodeScripts/capacityTest_initialiseQTs.js
@@ -11,8 +11,8 @@
 
 const config = require('./shared/config');
 const { auth, firebase, app, db } = require('./shared/admin.js');
-const action = require('../functions/actions/applications/applications')(config, firebase, db);
-const { initialiseApplicationRecords } = require('../functions/actions/applicationRecords')(config, auth, firebase, db);
+const action = require('../functions/actions/applications/applications')(config, firebase, db, auth);
+const { initialiseApplicationRecords } = require('../functions/actions/applicationRecords')(config, firebase, db, auth);
 const initialiseQualifyingTest = require('../functions/actions/qualifyingTests/initialiseQualifyingTest')(config, firebase, db);
 const {getDocument, getDocuments, applyUpdates} = require('../functions/shared/helpers');
 const { faker } = require('@faker-js/faker');

--- a/nodeScripts/capacityTest_initialiseQTs.js
+++ b/nodeScripts/capacityTest_initialiseQTs.js
@@ -10,9 +10,9 @@
  'use strict';
 
 const config = require('./shared/config');
-const { firebase, app, db } = require('./shared/admin.js');
+const { auth, firebase, app, db } = require('./shared/admin.js');
 const action = require('../functions/actions/applications/applications')(config, firebase, db);
-const { initialiseApplicationRecords } = require('../functions/actions/applicationRecords')(config, firebase, db);
+const { initialiseApplicationRecords } = require('../functions/actions/applicationRecords')(config, auth, firebase, db);
 const initialiseQualifyingTest = require('../functions/actions/qualifyingTests/initialiseQualifyingTest')(config, firebase, db);
 const {getDocument, getDocuments, applyUpdates} = require('../functions/shared/helpers');
 const { faker } = require('@faker-js/faker');

--- a/nodeScripts/createApplications.js
+++ b/nodeScripts/createApplications.js
@@ -10,8 +10,8 @@
  'use strict';
 
 const config = require('./shared/config');
-const { firebase, app, db } = require('./shared/admin.js');
-const action = require('../functions/actions/applications/applications')(config, firebase, db);
+const { firebase, app, db, auth } = require('./shared/admin.js');
+const action = require('../functions/actions/applications/applications')(config, firebase, db, auth);
 const {getDocument, getDocuments, applyUpdates} = require('../functions/shared/helpers');
 const { faker } = require('@faker-js/faker');
 

--- a/nodeScripts/initialiseApplicationRecords.js
+++ b/nodeScripts/initialiseApplicationRecords.js
@@ -2,7 +2,7 @@
 
 const config = require('./shared/config');
 const { auth, firebase, app, db } = require('./shared/admin.js');
-const { initialiseApplicationRecords } = require('../functions/actions/applicationRecords')(config, auth, firebase, db);
+const { initialiseApplicationRecords } = require('../functions/actions/applicationRecords')(config, firebase, db, auth);
 
 const main = async () => {
   return initialiseApplicationRecords({

--- a/nodeScripts/initialiseApplicationRecords.js
+++ b/nodeScripts/initialiseApplicationRecords.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const config = require('./shared/config');
-const { firebase, app, db } = require('./shared/admin.js');
-const { initialiseApplicationRecords } = require('../functions/actions/applicationRecords')(config, firebase, db);
+const { auth, firebase, app, db } = require('./shared/admin.js');
+const { initialiseMissingApplicationRecords } = require('../functions/actions/applicationRecords')(config, auth, firebase, db);
 
 const main = async () => {
-  return initialiseApplicationRecords({
-    exerciseId: '8CIlAsDbtMfr2vnfjmYh',
+  return initialiseMissingApplicationRecords({
+    exerciseId: '4xP8RY7GeoaS1yKqYJLw',
   });
 };
 

--- a/nodeScripts/initialiseApplicationRecords.js
+++ b/nodeScripts/initialiseApplicationRecords.js
@@ -2,10 +2,10 @@
 
 const config = require('./shared/config');
 const { auth, firebase, app, db } = require('./shared/admin.js');
-const { initialiseMissingApplicationRecords } = require('../functions/actions/applicationRecords')(config, auth, firebase, db);
+const { initialiseApplicationRecords } = require('../functions/actions/applicationRecords')(config, auth, firebase, db);
 
 const main = async () => {
-  return initialiseMissingApplicationRecords({
+  return initialiseApplicationRecords({
     exerciseId: '4xP8RY7GeoaS1yKqYJLw',
   });
 };

--- a/nodeScripts/sendCharacterCheckRequests.js
+++ b/nodeScripts/sendCharacterCheckRequests.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const config = require('./shared/config');
-const { firebase, app, db } = require('./shared/admin.js');
-const { sendCharacterCheckRequests } = require('../functions/actions/applications/applications')(config, firebase, db);
+const { firebase, app, db, auth } = require('./shared/admin.js');
+const { sendCharacterCheckRequests } = require('../functions/actions/applications/applications')(config, firebase, db, auth);
 
 const main = async () => {
   return sendCharacterCheckRequests({


### PR DESCRIPTION
Fixes a bug where cloud functions `onApplicationRecordUpdate` and `initialiseMissingApplicationRecords` were not behaving as expected.

The event logger module `logEvent` was loading the `auth` service directly rather than it being injected. This meant our app instance was effectively being initialised twice!

Have updated all instances of `logEvent` so that `auth` is now passed in.