### PR TITLE
Fix: Application record personal details defaults

### DIFF
--- a/functions/shared/factories.js
+++ b/functions/shared/factories.js
@@ -284,10 +284,10 @@ module.exports = (CONSTANTS) => {
       notes: [],
     };
     if (application.personalDetails) {
-      applicationRecord.candidate.fullName = application.personalDetails.fullName;
-      applicationRecord.candidate.reasonableAdjustments = application.personalDetails.reasonableAdjustments;
+      applicationRecord.candidate.fullName = application.personalDetails.fullName || null;
+      applicationRecord.candidate.reasonableAdjustments = application.personalDetails.reasonableAdjustments || null;
       applicationRecord.candidate.reasonableAdjustmentsDetails = application.personalDetails.reasonableAdjustments && application.personalDetails.reasonableAdjustmentsDetails ? application.personalDetails.reasonableAdjustmentsDetails : null;
-      applicationRecord.flags.reasonableAdjustments = application.personalDetails.reasonableAdjustments;
+      applicationRecord.flags.reasonableAdjustments = application.personalDetails.reasonableAdjustments || null;
     }
     return applicationRecord;
   }


### PR DESCRIPTION
Ensures `applicationRecord` documents can be created even when the `application` is missing some `personalDetails` data.
(with the default values the write to firestore was failing)