### PR TITLE
#715 Bugfix. Export exercise data should not include Draft applications

### DIFF
--- a/functions/actions/exercises/exportExerciseData.js
+++ b/functions/actions/exercises/exportExerciseData.js
@@ -63,18 +63,20 @@ module.exports = (config, firebase, db) => {
       const applications = await getDocuments(
         db.collection('applications')
           .where('exerciseId', '==', exercises[i].id)
+          .where('status', '!=', 'draft') // excludes any applications in Draft state
       );
       const joinedData = [];
       for (let j = 0, lenJ = applicationRecords.length; j < lenJ; j++) {
         const applicationRecord = applicationRecords[j];
-        // const application = await getDocument(db.collection('application').doc(applicationRecord.id));
         const application = applications.find(item => item.id === applicationRecord.id) || null;
-        joinedData.push({
-          id: applicationRecord.id,
-          application: application,
-          applicationRecord: applicationRecord,
-          exercise: exercise,
-        });
+        if (application) {
+          joinedData.push({
+            id: applicationRecord.id,
+            application: application,
+            applicationRecord: applicationRecord,
+            exercise: exercise,
+          });
+        }
       }
 
       const report = getReport(columns, joinedData);

--- a/functions/shared/helpers.js
+++ b/functions/shared/helpers.js
@@ -62,7 +62,7 @@ async function getAllDocuments(db, references) {
   if (references.length) {
     const snapshot = await db.getAll(...references);
     snapshot.forEach((doc) => {
-      const document = doc.data();
+      const document = { ...doc.data() };
       document.id = doc.id;
       document.ref = doc.ref;
       documents.push(document);

--- a/nodeScripts/query.exercisesMissingApplicationRecords.js
+++ b/nodeScripts/query.exercisesMissingApplicationRecords.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const { app, db, firebase } = require('./shared/admin.js');
+const { getDocuments } = require('../functions/shared/helpers');
+
+async function getExerciseStats(exerciseId) {
+
+  const stats = {
+    applications: {},
+    applicationRecords: {},
+    status: {},
+  };
+
+  const applications = await getDocuments(db.collection('applications').where('exerciseId', '==', exerciseId).select('status', 'userId', 'referenceNumber'));
+  stats.applications.total = applications.length;
+  applications.forEach(application => {
+    if (stats.applications[application.status]) {
+      stats.applications[application.status]++;
+    } else {
+      stats.applications[application.status] = 1;
+    }
+  });
+
+  const applicationRecords = await getDocuments(db.collection('applicationRecords').where('exercise.id', '==', exerciseId).select('stage', 'status', 'candidate'));
+  stats.applicationRecords.total = applicationRecords.length;
+  applicationRecords.forEach(applicationRecord => {
+    if (stats.applicationRecords[applicationRecord.stage]) {
+      stats.applicationRecords[applicationRecord.stage]++;
+    } else {
+      stats.applicationRecords[applicationRecord.stage] = 1;
+    }
+    if (stats.status[applicationRecord.status]) {
+      stats.status[applicationRecord.status]++;
+    } else {
+      stats.status[applicationRecord.status] = 1;
+    }
+  });
+
+
+  const applicationIds = applications.map(doc => doc.id);
+  const applicationRecordIds = applicationRecords.map(doc => doc.id);
+  const appliedApplicationIds = applications.filter(doc => doc.status === 'applied').map(doc => doc.id);
+
+  stats.orphanedApplications = applicationIds.filter(id => applicationRecordIds.indexOf(id) < 0).length;
+  stats.orphanedApplicationRecords = applicationRecordIds.filter(id => applicationIds.indexOf(id) < 0).length;
+  stats.orphanedAppliedApplicationIds = appliedApplicationIds.filter(id => applicationRecordIds.indexOf(id) < 0);
+  stats.orphanedAppliedApplications = stats.orphanedAppliedApplicationIds.length;
+  if (stats.orphanedAppliedApplications) {
+    stats.orphanedAppliedApplicationReferenceNumbers = applications.filter(app => stats.orphanedAppliedApplicationIds.indexOf(app.id) >= 0).map(app => app.referenceNumber);
+    stats.orphanedAppliedApplicationData = applications.filter(app => stats.orphanedAppliedApplicationIds.indexOf(app.id) >= 0);
+  }
+
+  const draftApplications = applications.filter(application => application.status === 'draft');
+  const draftApplicationsBeingProcessed = draftApplications.filter(application => applicationRecordIds.indexOf(application.id) >= 0);
+  stats.draftApplicationsBeingProcessed = draftApplicationsBeingProcessed; // .map(application => application.referenceNumber);
+
+  return stats;
+}
+
+const main = async () => {
+
+  const exercises = await getDocuments(
+    db.collection('exercises')
+      .where('applicationCloseDate', '<', new Date())
+      //.where(firebase.firestore.FieldPath.documentId(), 'in', ['6PZQoZ46Wk3GdsqAIzAl'])
+      .select('referenceNumber')
+  );
+  console.log('exercises', exercises.length);
+
+  const arrExerciseStats = await Promise.all(exercises.map(async (exercise) => {
+    return {
+      exerciseId: exercise.id,
+      stats: await getExerciseStats(exercise.id),
+    };
+  }));
+
+  // return arrExerciseStats;
+  // return arrExerciseStats.filter(report => report.stats.draftApplicationsBeingProcessed.length > 0).map(report => report.stats.draftApplicationsBeingProcessed.map(app => `${report.exerciseId}, ${app.id}, ${app.referenceNumber}`).join('\n')).join('\n');
+  return arrExerciseStats.filter(report => report.stats.orphanedAppliedApplications > 0).map(report => report.stats.orphanedAppliedApplicationData.map(app => `${report.exerciseId}, ${app.id}, ${app.referenceNumber}`).join('\n')).join('\n');
+
+};
+
+main()
+  .then((result) => {
+    console.log(result);
+    app.delete();
+    return process.exit();
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit();
+  });


### PR DESCRIPTION
Closes #715:

> The `exportExerciseData` callable function should not include those applications which have Applied and subsequently had their status changed to Draft.
> 
> **Actual** The exported data from `exportExerciseData` includes all applications which have applied and are being (or have been) processed. This includes any applications which have subsequently had their status changed to Draft
> 
> **Expected** The exported data from `exportExerciseData` includes all applications which have applied and are being (or have been) processed. This should exclude any applications that have subsequently had their status changed to Draft.

Also includes a script to help identify missing application records