### PR TITLE
virus scanning - write to log file max 1 time per second

### DIFF
--- a/functions/actions/malware-scanning/scanAllFiles.js
+++ b/functions/actions/malware-scanning/scanAllFiles.js
@@ -9,7 +9,7 @@ module.exports = (config, firebase) => {
   const SCAN_SERVICE_URL = `https://malware-scanner-dot-${PROJECT_ID}.appspot.com/scan`;
   const API_MAX_REQUEST = 100;
   const API_RATE_WINDOW_MS = 60000;
-  const UPDATE_LOG_FREQ = 10; // 10 = update the log file every 10 files that are processed
+  const UPDATE_LOG_FREQ = 20; // 10 = update the log file every 10 files that are processed
 
   return {
     scanAllFiles,
@@ -41,7 +41,7 @@ module.exports = (config, firebase) => {
     const processed = [];
     let exception = 'none';
 
-    createLogFile(bucket, started, processed, exception);
+    await createLogFile(bucket, started, processed, exception);
 
     try {
 
@@ -100,7 +100,7 @@ module.exports = (config, firebase) => {
 
         // update the log file every X files that are processed
         if (processed.length % UPDATE_LOG_FREQ === 0) {
-          createLogFile(bucket, started, processed, exception);
+          await createLogFile(bucket, started, processed, exception);
         }
 
       }
@@ -108,7 +108,7 @@ module.exports = (config, firebase) => {
       exception = e;
     }
 
-    createLogFile(bucket, started, processed, exception, true);
+    await createLogFile(bucket, started, processed, exception, true);
   }
 
   /**
@@ -176,6 +176,11 @@ ${JSON.stringify(exception, null, 2)}
 
     // delete local temp file
     fs.unlinkSync(tempFilePath);
+
+    // pause 1 second after updating the log file because this function is called multiple times
+    // and we are only allowed to update the log file max. 1 time per second
+    // ref: https://cloud.google.com/storage/docs/concepts-techniques#object-updates
+    await delayMS(1000);
 
   }
 


### PR DESCRIPTION
Bug Fix - the virus scanning job would abort abruptly for some reason

I did some research and found the following:

> That error happens when you attempt to update the same object too frequently. From https://cloud.google.com/storage/docs/concepts-techniques#object-updates:
> 
> There is no limit to how quickly you can create or update different objects in a bucket. However, a single particular object can only be updated or overwritten up to once per second.
> 

So, I made a change so that the log file is written to once per second at the most and that seemed to do the trick. Simple approach - every 20 files I pause execution for 1 second.