### PR TITLE
Bugfix. Agency report should include applications where 'consent' is true

### DIFF
--- a/functions/actions/exercises/generateAgencyReport.js
+++ b/functions/actions/exercises/generateAgencyReport.js
@@ -11,7 +11,7 @@ module.exports = (firebase, db) => {
     // get submitted applications that have character check declarations
     const applications = await getDocuments(db.collection('applications')
       .where('exerciseId', '==', exerciseId)
-      .where('characterChecks.declaration', '==', true));
+      .where('characterChecks.consent', '==', true));
 
     // get report headers
     const headers = reportHeaders();


### PR DESCRIPTION
Fixes a bug in the Agency Report

**Before**
Applications are only included in the report if they have `characterChecks.declaration` set to `true`

**After**
Applications are only included in the report if they have `characterChecks.consent` set to `true`