### PR TITLE
virus scanning - increase timeoutSeconds to prevent from timeout

### DIFF
--- a/functions/actions/malware-scanning/scanAllFiles.js
+++ b/functions/actions/malware-scanning/scanAllFiles.js
@@ -9,7 +9,7 @@ module.exports = (config, firebase) => {
   const SCAN_SERVICE_URL = `https://malware-scanner-dot-${PROJECT_ID}.appspot.com/scan`;
   const API_MAX_REQUEST = 100;
   const API_RATE_WINDOW_MS = 60000;
-  const UPDATE_LOG_FREQ = 10; // 10 = update the log file every 10 files that are processed
+  const UPDATE_LOG_FREQ = 20; // 10 = update the log file every 10 files that are processed
 
   return {
     scanAllFiles,
@@ -41,7 +41,7 @@ module.exports = (config, firebase) => {
     const processed = [];
     let exception = 'none';
 
-    createLogFile(bucket, started, processed, exception);
+    await createLogFile(bucket, started, processed, exception);
 
     try {
 
@@ -100,7 +100,7 @@ module.exports = (config, firebase) => {
 
         // update the log file every X files that are processed
         if (processed.length % UPDATE_LOG_FREQ === 0) {
-          createLogFile(bucket, started, processed, exception);
+          await createLogFile(bucket, started, processed, exception);
         }
 
       }
@@ -108,7 +108,7 @@ module.exports = (config, firebase) => {
       exception = e;
     }
 
-    createLogFile(bucket, started, processed, exception, true);
+    await createLogFile(bucket, started, processed, exception, true);
   }
 
   /**
@@ -176,6 +176,11 @@ ${JSON.stringify(exception, null, 2)}
 
     // delete local temp file
     fs.unlinkSync(tempFilePath);
+
+    // pause 1 second after updating the log file because this function is called multiple times
+    // and we are only allowed to update the log file max. 1 time per second
+    // ref: https://cloud.google.com/storage/docs/concepts-techniques#object-updates
+    await delayMS(1000);
 
   }
 

--- a/functions/scheduledFunctions/scheduleScanAllFiles.js
+++ b/functions/scheduledFunctions/scheduleScanAllFiles.js
@@ -5,8 +5,12 @@ const { scanAllFiles } = require('../actions/malware-scanning/scanAllFiles')(con
 
 // const SCHEDULE = 'every day 02:00';
 const SCHEDULE = 'every 1 hours'; // this setting is temporary
+const runtimeOptions = {
+  timeoutSeconds: 540, // maximum value is 540
+};
 
 module.exports = functions.region('europe-west2')
+  .runWith(runtimeOptions)
   .pubsub
   .schedule(SCHEDULE)
   .timeZone('Europe/London')


### PR DESCRIPTION
Bug Fix - the virus scanning job would abort due to the default `timeoutSeconds` which is 1 minute.

So, I increased `timeoutSeconds` to the maximum value which is 9 minutes.
<img width="744" alt="scheduleScanAllFiles timeout" src="https://user-images.githubusercontent.com/79906532/171389321-a2e02a73-54eb-4cd8-a66a-648a1d72aa5d.png">
<img width="1322" alt="scheduleScanAllFiles timeoutSeconds 9 mins" src="https://user-images.githubusercontent.com/79906532/171389339-a352b92d-36de-4fdb-9d23-3dd5b07f61b7.png">
<img width="1242" alt="scheduleScanAllFiles status ok" src="https://user-images.githubusercontent.com/79906532/171389352-fc2a2090-5cee-4208-876f-af7faa4b4d5c.png">

