### PR TITLE
Bugfix. Generate agency report undefined value error

### DIFF
--- a/functions/actions/exercises/generateAgencyReport.js
+++ b/functions/actions/exercises/generateAgencyReport.js
@@ -83,7 +83,7 @@ const reportData = (db, applications) => {
       sraNumber: sra ? sra.membershipNumber || null : null,
       bsbDate: bsb ? helpers.formatDate(bsb.date) : null,
       bsbNumber: bsb ? bsb.membershipNumber || null : null,
-      jcioOffice: helpers.toYesNo(application.feePaidOrSalariedJudge),
+      jcioOffice: helpers.toYesNo(application.feePaidOrSalariedJudge) || null,
       jcioPosts: application.experience ? application.experience.map(e => e.jobTitle).join(', ') : null,
       hmrcVATNumbers: application.personalDetails.hasVATNumbers ? application.personalDetails.VATNumbers.map(e => e.VATNumber).join(', ') : null,
       gmcDate: helpers.formatDate(application.generalMedicalCouncilDate),


### PR DESCRIPTION
Fixes a bug when generating the Agency Report:

<img width="1231" alt="generateAgencyReport undefined error" src="https://user-images.githubusercontent.com/79906532/174627134-8a035235-2d0b-4b97-acb9-49f3b1caaa5c.png">

Solution: set `jcioOffice` to `null` if it is `undefined`.