### PR TITLE
1393 virus scanning improvements - one instance app

### DIFF
--- a/functions/actions/malware-scanning/scanAllFiles.js
+++ b/functions/actions/malware-scanning/scanAllFiles.js
@@ -5,8 +5,7 @@ const path = require('path');
 
 module.exports = (config, firebase) => {
 
-  const PROJECT_ID = config.PROJECT_ID;
-  const SCAN_SERVICE_URL = `https://malware-scanner-dot-${PROJECT_ID}.appspot.com/scan`;
+  const SCAN_SERVICE_URL = config.SCAN_SERVICE_URL;
   const API_MAX_REQUEST = 100;
   const API_RATE_WINDOW_MS = 60000;
   const UPDATE_LOG_FREQ = 20; // 10 = update the log file every 10 files that are processed

--- a/functions/actions/malware-scanning/scanAllFiles.js
+++ b/functions/actions/malware-scanning/scanAllFiles.js
@@ -148,6 +148,7 @@ module.exports = (config, firebase) => {
     const content = `
 Virus Scanning Log
 
+Scan service url: ${SCAN_SERVICE_URL}
 Start time: ${getScannedDateTime(started)}
 End time: ${getScannedDateTime(Date.now())}
 

--- a/functions/actions/malware-scanning/scanAllFiles.js
+++ b/functions/actions/malware-scanning/scanAllFiles.js
@@ -31,6 +31,7 @@ module.exports = (config, firebase) => {
       uri: SCAN_SERVICE_URL,
       body: {
         filename: null,
+        projectId: firebase.instanceId().app.options.projectId,
       },
       json: true,
     };

--- a/functions/actions/malware-scanning/scanFile.js
+++ b/functions/actions/malware-scanning/scanFile.js
@@ -33,6 +33,7 @@ module.exports = (config, firebase) => {
         uri: SCAN_SERVICE_URL,
         body: {
           filename: fileURL,
+          projectId: firebase.instanceId().app.options.projectId,
         },
         json: true,
       };

--- a/functions/actions/malware-scanning/scanFile.js
+++ b/functions/actions/malware-scanning/scanFile.js
@@ -1,10 +1,8 @@
-const functions = require('firebase-functions');
 const request = require('request-promise');
 
 module.exports = (config, firebase) => {
 
-  const PROJECT_ID = functions.config().project.id;
-  const SCAN_SERVICE_URL = `https://malware-scanner-dot-${PROJECT_ID}.appspot.com/scan`;
+  const SCAN_SERVICE_URL = config.SCAN_SERVICE_URL;
 
   return {
     scanFile,

--- a/functions/shared/config.js
+++ b/functions/shared/config.js
@@ -210,5 +210,6 @@ module.exports = {
   NOTIFY_KEY: functions.config().notify.key,
   SLACK_URL: functions.config().slack.url,
   STORAGE_URL: functions.config().project.id + '.appspot.com',
+  SCAN_SERVICE_URL: functions.config().scan_service.url,
 };
 


### PR DESCRIPTION
**Author checklist**

- [x] Include primary ticket number in title - e.g. "#123 New styling for widget" - and any additional tickets in description
- [x] Fill in the details below and delete as appropriate
- [x] Be proactive in getting your work approved 💪

---
## What's included?
Allow one instance of the scan service app to scan develop, staging and production environments.

Related issue: [#1393 Virus scanning improvements](https://app.zenhub.com/workspaces/platform-development-5ea838cd2aec471eb6d14139/issues/jac-uk/admin/1393)

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

- Deploy the virus scanning instance to staging
- Go to cloud storage to set the permission that allows staging service account to access develop bucket

    <img width="1499" alt="Screenshot 2022-07-06 at 12 12 53" src="https://user-images.githubusercontent.com/79906532/177538727-4284c935-9369-45f5-afa6-4a7e9f601e51.png">

- Deploy cloud functions `scanFile` and `scanAllFiles` to develop and staging
- Set environment variable `scan_service.url` of develop and staging with the intention of both using the staging instance of the virus scanning service
    ```
    firebase functions:config:set scan_service.url=https://malware-scanner-dot-digital-platform-staging.appspot.com/scan
    ```
- Go to folder `virusScanningLogs` to check virus scanning is running


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
