### PR TITLE
Handover Report - Deployment Information

### DIFF
--- a/functions/actions/exercises/generateHandoverReport.js
+++ b/functions/actions/exercises/generateHandoverReport.js
@@ -256,15 +256,18 @@ const formatDiversityData = (survey, exercise) => {
 };
 
 const formatLegalData = (application) => {
-  const qualifications = application.qualifications.map(qualification => {
-    return [
-      lookup(qualification.location),
-      lookup(qualification.type),
-      helpers.formatDate(qualification.date),
-      qualification.membershipNumber,
-    ].join(' ');
-  }).join('\n');
-
+  let qualifications = '';
+  if (application.qualifications && Array.isArray(application.qualifications)) {
+    qualifications = application.qualifications.map(qualification => {
+      return [
+        lookup(qualification.location),
+        lookup(qualification.type),
+        helpers.formatDate(qualification.date),
+        qualification.membershipNumber,
+      ].join(' ');
+    }).join('\n');
+  }
+  
   let judicialExperience;
   if (application.feePaidOrSalariedJudge) {
     judicialExperience = `Fee paid or salaried judge - ${lookup(application.feePaidOrSalariedSittingDaysDetails)} days`;

--- a/functions/actions/exercises/generateHandoverReport.js
+++ b/functions/actions/exercises/generateHandoverReport.js
@@ -150,12 +150,13 @@ const reportData = (db, exercise, applicationRecords, applications) => {
     }
 
     const locationPreferences = application.locationPreferences && application.locationPreferences.length
-      ? getLocationPreferences(application, exercise).map(x => `${removeHtml(x.label)} ${removeHtml(x.value)}`).join('\n\n') : '';
+      ? getLocationPreferences(application, exercise).map(x => `${removeHtml(x.label)}\n${removeHtml(x.value)}`).join('\n\n') : '';
     const jurisdictionPreferences = application.jurisdictionPreferences && application.jurisdictionPreferences.length
-      ? getJurisdictionPreferences(application, exercise).map(x => `${removeHtml(x.label)} ${removeHtml(x.value)}`).join('\n\n') : '';
+      ? getJurisdictionPreferences(application, exercise).map(x => `${removeHtml(x.label)}\n${removeHtml(x.value)}`).join('\n\n') : '';
     const additionalPreferences = application.additionalWorkingPreferences && application.additionalWorkingPreferences.length
-      ? getAdditionalWorkingPreferences(application, exercise).map(x => `${removeHtml(x.label)} ${removeHtml(x.value)}`).join('\n\n') : '';
-    const welshPosts = getWelshData(application).map(x => `${removeHtml(x.label)} ${removeHtml(x.value)}`).join('\n\n');
+      ? getAdditionalWorkingPreferences(application, exercise).map(x => `${removeHtml(x.label)}\n${removeHtml(x.value)}`).join('\n\n') : '';
+    const welshPosts = exercise.welshRequirement
+      ? getWelshData(application).map(x => `${removeHtml(x.label)}\n${removeHtml(x.value)}`).join('\n\n') : '';
 
     // return report data for this application
     return {

--- a/functions/actions/exercises/generateHandoverReport.js
+++ b/functions/actions/exercises/generateHandoverReport.js
@@ -1,6 +1,8 @@
 const helpers = require('../../shared/converters/helpers');
 const lookup = require('../../shared/converters/lookup');
-const { getDocument, getDocuments, getAllDocuments } = require('../../shared/helpers');
+const { getDocument, getDocuments, getAllDocuments, removeHtml } = require('../../shared/helpers');
+const applicationConverter = require('../../shared/converters/applicationConverter')();
+const { getLocationPreferences, getJurisdictionPreferences, getAdditionalWorkingPreferences, getWelshData } = applicationConverter;
 
 module.exports = (firebase, db) => {
   return {
@@ -115,6 +117,13 @@ const reportHeaders = (exercise) => {
     reportHeaders.push(...headers.diversity.common);
   }
 
+  reportHeaders.push(
+    { title: 'Location Preferences', ref: 'locationPreferences' },
+    { title: 'Jurisdiction Preferences', ref: 'jurisdictionPreferences' },
+    { title: 'Additional Preferences', ref: 'additionalPreferences' },
+    { title: 'Welsh posts', ref: 'welshPosts' }
+  );
+
   return reportHeaders;
 };
 
@@ -140,6 +149,14 @@ const reportData = (db, exercise, applicationRecords, applications) => {
       memberships = formatNonLegalData(application, exercise);
     }
 
+    const locationPreferences = application.locationPreferences && application.locationPreferences.length
+      ? getLocationPreferences(application, exercise).map(x => `${removeHtml(x.label)} ${removeHtml(x.value)}`).join('\n\n') : '';
+    const jurisdictionPreferences = application.jurisdictionPreferences && application.jurisdictionPreferences.length
+      ? getJurisdictionPreferences(application, exercise).map(x => `${removeHtml(x.label)} ${removeHtml(x.value)}`).join('\n\n') : '';
+    const additionalPreferences = application.additionalWorkingPreferences && application.additionalWorkingPreferences.length
+      ? getAdditionalWorkingPreferences(application, exercise).map(x => `${removeHtml(x.label)} ${removeHtml(x.value)}`).join('\n\n') : '';
+    const welshPosts = getWelshData(application).map(x => `${removeHtml(x.label)} ${removeHtml(x.value)}`).join('\n\n');
+
     // return report data for this application
     return {
       applicationId: application.id,
@@ -149,6 +166,10 @@ const reportData = (db, exercise, applicationRecords, applications) => {
       ...qualifications,
       ...memberships,
       ...formatDiversityData(application.equalityAndDiversitySurvey, exercise),
+      locationPreferences,
+      jurisdictionPreferences,
+      additionalPreferences,
+      welshPosts,
     };
 
   });
@@ -160,9 +181,15 @@ const getCandidateId = (applicationRecords, application) => {
 };
 
 const formatPersonalDetails = (personalDetails) => {
-  const formatAddress = (address =>
-    `${address.street} ${address.street2} ${address.town} ${address.county} ${address.postcode} `
-  );
+  const formatAddress = (address => {
+    const result = [];
+    if (address.street) result.push(address.street);
+    if (address.street2) result.push(address.street2);
+    if (address.town) result.push(address.town);
+    if (address.county) result.push(address.county);
+    if (address.postcode) result.push(address.postcode);
+    return `${result.join(' ')} `;
+  });
 
   let formattedPreviousAddresses;
   if (personalDetails.address && !personalDetails.address.currentMoreThan5Years) {

--- a/functions/actions/exercises/getApplicationData.js
+++ b/functions/actions/exercises/getApplicationData.js
@@ -1,7 +1,6 @@
 const { getDocument, getDocuments, formatDate } = require('../../shared/helpers');
 
 const _ = require('lodash');
-const { instance } = require('firebase-functions/v1/database');
 
 function formatPreference(choiceArray, questionType) {
   if(questionType === 'multiple-choice') {
@@ -11,7 +10,7 @@ function formatPreference(choiceArray, questionType) {
   } else if (questionType === 'single-choice') {
     return choiceArray;
   }
-};
+}
 
 module.exports = (config, firebase, db, auth) => {
 
@@ -51,11 +50,11 @@ module.exports = (config, firebase, db, auth) => {
         }
         // Handle array values
         else if (['locationPreferences', 'jurisdictionPreferences'].includes(column)) {
-          if (column == 'locationPreferences') {
+          if (column === 'locationPreferences') {
             // console.log(record[column], exerciseData.locationQuestionType);
             record[column] = formatPreference(record[column], exerciseData.locationQuestionType);
           } 
-          if (column == 'jurisdictionPreferences') {
+          if (column === 'jurisdictionPreferences') {
             record[column] = formatPreference(record[column], exerciseData.jurisdictionQuestionType);
           } 
         }

--- a/functions/shared/converters/applicationConverter.js
+++ b/functions/shared/converters/applicationConverter.js
@@ -262,7 +262,7 @@ module.exports = () => {
   function getWelshData(application) {
     const data = [];
     addField(data, 'Applying for Welsh posts?', toYesNo(application.applyingForWelshPost));
-    if (application.applyingForWelshPost) {
+    if ('applyingForWelshPost' in application) {
       addField(data, 'Can speak Welsh?', toYesNo(application.canSpeakWelsh));
 
       if (application.canReadAndWriteWelsh === false) {

--- a/functions/shared/converters/applicationConverter.js
+++ b/functions/shared/converters/applicationConverter.js
@@ -9,6 +9,10 @@ module.exports = () => {
   return {
     getHtmlPanelPack,
     getAdditionalSelectionCriteria,
+    getLocationPreferences,
+    getJurisdictionPreferences,
+    getAdditionalWorkingPreferences,
+    getWelshData,
     // TODO include other converters
   };
 
@@ -257,7 +261,7 @@ module.exports = () => {
 
   function getWelshData(application) {
     const data = [];
-    addField(data, 'Applying for Welsh posts', toYesNo(application.applyingForWelshPost));
+    addField(data, 'Applying for Welsh posts?', toYesNo(application.applyingForWelshPost));
     if (application.applyingForWelshPost) {
       addField(data, 'Can speak Welsh?', toYesNo(application.canSpeakWelsh));
 

--- a/functions/shared/helpers.js
+++ b/functions/shared/helpers.js
@@ -18,6 +18,7 @@ module.exports = {
   getLatestDate,
   convertStringToSearchParts,
   isProduction,
+  removeHtml,
 };
 
 async function getDocument(query) {
@@ -258,4 +259,8 @@ function convertStringToSearchParts(value, delimiter) {
 function isProduction() {
   const projectId = firebase.instanceId().app.options.projectId;
   return projectId.includes('production');
+}
+
+function removeHtml(str) {
+  return str.replace(/<[^>]*>?/gm, '');
 }

--- a/functions/shared/helpers.js
+++ b/functions/shared/helpers.js
@@ -262,5 +262,5 @@ function isProduction() {
 }
 
 function removeHtml(str) {
-  return str.replace(/<[^>]*>?/gm, '');
+  return str.replace(/(<([^>]+)>)/gi, '');
 }

--- a/test/shared/helpers.spec.js
+++ b/test/shared/helpers.spec.js
@@ -1,4 +1,4 @@
-const { checkArguments, applyUpdates, convertStringToSearchParts, getEarliestDate, getLatestDate } = require('../../functions/shared/helpers');
+const { checkArguments, applyUpdates, convertStringToSearchParts, getEarliestDate, getLatestDate, removeHtml } = require('../../functions/shared/helpers');
 
 describe('checkArguments()', () => {
 
@@ -427,5 +427,14 @@ describe('getLatestDate()', () => {
       expect(getLatestDate(arrayOfDates2)).toBe(laterDate);
       expect(getLatestDate(arrayOfDates3)).toBe(laterDate);
     });
+  });
+});
+
+describe('removeHtml', () => {
+  it('remove HTML tags from a given string', () => {
+    expect(removeHtml('<div>title</div>')).toBe('title');
+    expect(removeHtml('<br>1. answer')).toBe('1. answer');
+    expect(removeHtml('<br/>1. answer')).toBe('1. answer');
+    expect(removeHtml('<br />1. answer')).toBe('1. answer');
   });
 });


### PR DESCRIPTION
## What's included?
Add data needed to the handover report.

- [x] Location Preferences (Circuit Preference)
- [x] Candidates' full address, including postcode
- [x] Jurisdiction Preferences
- [x] Additional Preferences
- [x] Welsh Posts

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Use postman to call `generateHandoverReport` endpoint.

Admin site:
1. Go to Handover report of an exercise
2. Click refresh button and then export data
3. Open excel file and check extra columns that are added to the report 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/181777097-05fd681b-1aa5-4dbb-8d92-5fbbe3eb7881.mov

## Related permissions
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
