### PR TITLE
#1393 Virus scanning log file update

### DIFF
--- a/functions/actions/malware-scanning/scanAllFiles.js
+++ b/functions/actions/malware-scanning/scanAllFiles.js
@@ -8,7 +8,7 @@ module.exports = (config, firebase) => {
   const SCAN_SERVICE_URL = config.SCAN_SERVICE_URL;
   const API_MAX_REQUEST = 100;
   const API_RATE_WINDOW_MS = 60000;
-  const UPDATE_LOG_SECOND = 10; // the rate limit to bucket creation and deletion is approximately 1 request every 2 seconds
+  const UPDATE_LOG_SECOND = 10; // there's a write limit (once per second) to the same object name
 
   return {
     scanAllFiles,

--- a/functions/actions/malware-scanning/scanAllFiles.js
+++ b/functions/actions/malware-scanning/scanAllFiles.js
@@ -8,7 +8,7 @@ module.exports = (config, firebase) => {
   const SCAN_SERVICE_URL = config.SCAN_SERVICE_URL;
   const API_MAX_REQUEST = 100;
   const API_RATE_WINDOW_MS = 60000;
-  const UPDATE_LOG_FREQ = 20; // 10 = update the log file every 10 files that are processed
+  const UPDATE_LOG_SECOND = 10; // the rate limit to bucket creation and deletion is approximately 1 request every 2 seconds
 
   return {
     scanAllFiles,
@@ -23,6 +23,7 @@ module.exports = (config, firebase) => {
   async function scanAllFiles(force = false, maxFiles = 999999) {
 
     const started = Date.now();
+    let lastUpdate = started;
 
     // setup the HTTP request to the malware scanner web service
     const options = {
@@ -98,9 +99,11 @@ module.exports = (config, firebase) => {
           break;
         }
 
-        // update the log file every X files that are processed
-        if (processed.length % UPDATE_LOG_FREQ === 0) {
+        // update the log file every X seconds
+        const diffSecond = Math.round((Date.now() - lastUpdate) / 1000);
+        if (diffSecond >= UPDATE_LOG_SECOND) {
           await createLogFile(bucket, started, processed, exception);
+          lastUpdate = Date.now();
         }
 
       }

--- a/functions/actions/malware-scanning/scanFile.js
+++ b/functions/actions/malware-scanning/scanFile.js
@@ -13,6 +13,15 @@ module.exports = (config, firebase) => {
    */
   async function scanFile(fileURL) {
     try {
+
+      // skip virus scanning logs files
+      if (fileURL.includes('virusScanningLogs') && fileURL.endsWith('.json')) {
+        return {
+          result: 'skip',
+          error: 'virus scanning logs file',
+        };
+      }
+
       const bucket = firebase.storage().bucket(config.STORAGE_URL);
       const file = bucket.file(fileURL);
       const exists = (await file.exists())[0]; // the exists() function returns an array with a single boolean element in it

--- a/functions/scheduledFunctions/scheduleScanAllFiles.js
+++ b/functions/scheduledFunctions/scheduleScanAllFiles.js
@@ -7,6 +7,7 @@ const { scanAllFiles } = require('../actions/malware-scanning/scanAllFiles')(con
 const SCHEDULE = 'every 1 hours'; // this setting is temporary
 const runtimeOptions = {
   timeoutSeconds: 540, // maximum value is 540
+  memory: '1GB',
 };
 
 module.exports = functions.region('europe-west2')

--- a/test/functions/scanFile.spec.js
+++ b/test/functions/scanFile.spec.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const { firebaseFunctionsTest, generateMockContext } = require('./helpers');
+const scanFile = require('../../functions/callableFunctions/scanFile');
+
+const { wrap } = firebaseFunctionsTest;
+
+describe('scanFile', () => {
+  it ('Scan file except virus scanning logs file', async () => {
+    const wrapped = wrap(scanFile);
+    let res = null;
+    res = await wrapped({ fileURL: 'https://storage.googleapis.com/upload/storage/v1/b/digital-platform-develop.appspot.com/o?uploadType=multipart&name=virusScanningLogs/2022-08-04T00:00:00.000Z.doc' }, generateMockContext());
+    assert.equal(res.result, 'error');
+    res = await wrapped({ fileURL: 'https://storage.googleapis.com/upload/storage/v1/b/digital-platform-develop.appspot.com/o?uploadType=multipart&name=logs/2022-08-04T00:00:00.000Z.json' }, generateMockContext());
+    assert.equal(res.result, 'error');
+  });
+  it ('Skip virus scanning logs file', async () => {
+    const wrapped = wrap(scanFile);
+    const res = await wrapped({ fileURL: 'https://storage.googleapis.com/upload/storage/v1/b/digital-platform-develop.appspot.com/o?uploadType=multipart&name=virusScanningLogs/2022-08-04T00:00:00.000Z.json' }, generateMockContext());
+    assert.equal(res.result, 'skip');
+  });
+});


### PR DESCRIPTION
## What's included?

- [x] Skip to scan the virus scanning log file when it's upload to the Google cloud bucket.
- [x] Update virus scanning log every 10 seconds since there's a write limit (once per second) to the same object name.
- [x] Increase memory (256MB to 1GB) for scheduleScanAllFiles due to `Error: memory limit exceeded` on production.

Note: error screenshots:
![image](https://user-images.githubusercontent.com/79906532/183053722-fdcaab2b-25fa-4cad-bc12-72a0d1bbe9d2.png)

<img width="951" alt="Screenshot 2022-08-05 at 12 03 01" src="https://user-images.githubusercontent.com/79906532/183064599-c2eb73b9-532c-4515-9af7-181d122f3738.png">

## Who should test?
✅ Developers

## How to test?
1. Run `npm run test:functions` to test `scanFile` function
2. Use Postman to test `scanAllFiles` endpoint

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

## Related permissions
- No permission changes required

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
