### PR TITLE
Update assessments functions

### DIFF
--- a/database/firestore.indexes.json
+++ b/database/firestore.indexes.json
@@ -123,11 +123,85 @@
           "order": "ASCENDING"
         },
         {
+          "fieldPath": "scenario.panelId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "candidate.fullName",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "applicationRecords",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "active",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "exercise.id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "scenario.panelId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "candidate.fullName",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "applicationRecords",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "active",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "exercise.id",
+          "order": "ASCENDING"
+        },
+        {
           "fieldPath": "selection.panelId",
           "order": "ASCENDING"
         },
         {
           "fieldPath": "stage",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "candidate.fullName",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "applicationRecords",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "active",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "exercise.id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "selection.panelId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
           "order": "ASCENDING"
         },
         {
@@ -171,7 +245,55 @@
           "order": "ASCENDING"
         },
         {
+          "fieldPath": "candidate.fullName",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "applicationRecords",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "active",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "exercise.id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "sift.panelId",
+          "order": "ASCENDING"
+        },
+        {
           "fieldPath": "stage",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "candidate.fullName",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "applicationRecords",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "active",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "exercise.id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "sift.panelId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
           "order": "ASCENDING"
         },
         {
@@ -396,6 +518,24 @@
         },
         {
           "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "applicationRecords",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "candidate.id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "flags.characterIssues",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "exercise.id",
           "order": "ASCENDING"
         }
       ]
@@ -1131,6 +1271,28 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "assessor.type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "exercise.id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "candidate.fullName",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "assessments",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "exercise.id",
           "order": "ASCENDING"
         },
@@ -1151,6 +1313,24 @@
         {
           "fieldPath": "candidate.fullName",
           "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "assessments",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "exercise.id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "candidate.fullName",
+          "order": "ASCENDING"
         }
       ]
     },
@@ -1409,7 +1589,119 @@
           "order": "ASCENDING"
         },
         {
+          "fieldPath": "_applications._total",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "exercises",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "state",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_applications._total",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "exercises",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "state",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "applicationCloseDate",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "exercises",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "state",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "applicationCloseDate",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "exercises",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "state",
+          "order": "ASCENDING"
+        },
+        {
           "fieldPath": "applicationOpenDate",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "exercises",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "state",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "applicationOpenDate",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "exercises",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "state",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "exercises",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "state",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "exercises",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "state",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "referenceNumber",
           "order": "ASCENDING"
         }
       ]
@@ -1425,6 +1717,20 @@
         {
           "fieldPath": "referenceNumber",
           "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "exercises",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "state",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "referenceNumber",
+          "order": "ASCENDING"
         }
       ]
     },

--- a/database/firestore.indexes.json
+++ b/database/firestore.indexes.json
@@ -123,54 +123,6 @@
           "order": "ASCENDING"
         },
         {
-          "fieldPath": "scenario.panelId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "candidate.fullName",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "applicationRecords",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "active",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "exercise.id",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "scenario.panelId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "status",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "candidate.fullName",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "applicationRecords",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "active",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "exercise.id",
-          "order": "ASCENDING"
-        },
-        {
           "fieldPath": "selection.panelId",
           "order": "ASCENDING"
         },
@@ -197,55 +149,7 @@
           "order": "ASCENDING"
         },
         {
-          "fieldPath": "selection.panelId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "status",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "candidate.fullName",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "applicationRecords",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "active",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "exercise.id",
-          "order": "ASCENDING"
-        },
-        {
           "fieldPath": "sift.panelId",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "applicationRecords",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "active",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "exercise.id",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "sift.panelId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "candidate.fullName",
           "order": "ASCENDING"
         }
       ]
@@ -268,32 +172,6 @@
         },
         {
           "fieldPath": "stage",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "candidate.fullName",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "applicationRecords",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "active",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "exercise.id",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "sift.panelId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "status",
           "order": "ASCENDING"
         },
         {
@@ -518,24 +396,6 @@
         },
         {
           "fieldPath": "status",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "applicationRecords",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "candidate.id",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "flags.characterIssues",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "exercise.id",
           "order": "ASCENDING"
         }
       ]
@@ -1317,24 +1177,6 @@
       ]
     },
     {
-      "collectionGroup": "assessments",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "exercise.id",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "status",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "candidate.fullName",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
       "collectionGroup": "candidates",
       "queryScope": "COLLECTION",
       "fields": [
@@ -1589,62 +1431,6 @@
           "order": "ASCENDING"
         },
         {
-          "fieldPath": "_applications._total",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "exercises",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "state",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "_applications._total",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "exercises",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "state",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "applicationCloseDate",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "exercises",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "state",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "applicationCloseDate",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "exercises",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "state",
-          "order": "ASCENDING"
-        },
-        {
           "fieldPath": "applicationOpenDate",
           "order": "ASCENDING"
         }
@@ -1659,78 +1445,8 @@
           "order": "ASCENDING"
         },
         {
-          "fieldPath": "applicationOpenDate",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "exercises",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "state",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "name",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "exercises",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "state",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "name",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "exercises",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "state",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "referenceNumber",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "exercises",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "state",
-          "order": "ASCENDING"
-        },
-        {
           "fieldPath": "referenceNumber",
           "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "exercises",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "state",
-          "order": "DESCENDING"
-        },
-        {
-          "fieldPath": "referenceNumber",
-          "order": "ASCENDING"
         }
       ]
     },

--- a/database/firestore.indexes.json
+++ b/database/firestore.indexes.json
@@ -1177,6 +1177,132 @@
       ]
     },
     {
+      "collectionGroup": "assessments",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "exercise.id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "application.referenceNumber",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "assessments",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "exercise.id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "application.referenceNumber",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "assessments",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "exercise.id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "assessor.fullName",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "assessments",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "exercise.id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "assessor.fullName",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "assessments",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "exercise.id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "assessor.type",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "assessments",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "exercise.id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "candidate.fullName",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "assessments",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "exercise.id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "candidate.fullName",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "candidates",
       "queryScope": "COLLECTION",
       "fields": [

--- a/database/firestore.rules
+++ b/database/firestore.rules
@@ -234,7 +234,7 @@ service cloud.firestore {
         (!('id' in request.resource.data.assessor) || request.resource.data.assessor.id == currentUser()) &&
         resource.data.assessor.email == request.resource.data.assessor.email &&
         resource.data.status == 'pending' &&
-        (request.resource.data.status == 'completed' || request.resource.data.status == 'cancelled' || request.resource.data.status == 'declined') &&
+        (request.resource.data.status == 'completed' || request.resource.data.status == 'declined') &&
         request.time <= resource.data.dueDate;
         // TODO allow uploads after the due date but before the hard limit resource.data.dueDate >= request.time;
     }

--- a/database/firestore.rules
+++ b/database/firestore.rules
@@ -234,7 +234,7 @@ service cloud.firestore {
         (!('id' in request.resource.data.assessor) || request.resource.data.assessor.id == currentUser()) &&
         resource.data.assessor.email == request.resource.data.assessor.email &&
         resource.data.status == 'pending' &&
-        request.resource.data.status == 'completed' &&
+        (request.resource.data.status == 'completed' || request.resource.data.status == 'cancelled' || request.resource.data.status == 'declined') &&
         request.time <= resource.data.dueDate;
         // TODO allow uploads after the due date but before the hard limit resource.data.dueDate >= request.time;
     }

--- a/functions/actions/assessments.js
+++ b/functions/actions/assessments.js
@@ -1,7 +1,7 @@
 const { getDocument, getDocuments, getAllDocuments, applyUpdates } = require('../shared/helpers');
 
 module.exports = (config, firebase, db) => {
-  const { newAssessment, newNotificationAssessmentRequest, newNotificationAssessmentReminder } = require('../shared/factories')(config);
+  const { newAssessment, newNotificationAssessmentRequest, newNotificationAssessmentReminder, newNotificationAssessmentSubmit } = require('../shared/factories')(config);
   const { testNotification } = require('./notifications')(config, db);
 
   return {
@@ -48,6 +48,13 @@ module.exports = (config, firebase, db) => {
         command: 'update',
         ref: db.collection('exercises').doc(assessment.exercise.id),
         data: { 'assessments.completed': increment },
+      });
+
+      // send notification
+      commands.push({
+        command: 'set',
+        ref: db.collection('notifications').doc(),
+        data: newNotificationAssessmentSubmit(firebase, assessment),
       });
     }
     // write to db

--- a/functions/actions/assessments.js
+++ b/functions/actions/assessments.js
@@ -306,6 +306,8 @@ module.exports = (config, firebase, db) => {
         completed = (completed && completed - assessments.length >= 0) ? completed - assessments.length : completed;
       } else if (prevStatus === 'completed' && ['pending'].includes(params.status)) {
         completed = (completed && completed - assessments.length >= 0) ? completed - assessments.length : completed;
+      } else if (prevStatus === 'declined' && ['draft'].includes(params.status)) {
+        sent = (sent && sent - assessments.length >= 0) ? sent - assessments.length : sent;
       }
 
       commands.push({

--- a/functions/actions/exercises/getApplicationData.js
+++ b/functions/actions/exercises/getApplicationData.js
@@ -1,7 +1,6 @@
 const { getDocument, getDocuments, formatDate } = require('../../shared/helpers');
 
 const _ = require('lodash');
-const { instance } = require('firebase-functions/v1/database');
 
 function formatPreference(choiceArray, questionType) {
   if(questionType === 'multiple-choice') {
@@ -11,7 +10,7 @@ function formatPreference(choiceArray, questionType) {
   } else if (questionType === 'single-choice') {
     return choiceArray;
   }
-};
+}
 
 module.exports = (config, firebase, db, auth) => {
 
@@ -51,11 +50,11 @@ module.exports = (config, firebase, db, auth) => {
         }
         // Handle array values
         else if (['locationPreferences', 'jurisdictionPreferences'].includes(column)) {
-          if (column == 'locationPreferences') {
+          if (column === 'locationPreferences') {
             // console.log(record[column], exerciseData.locationQuestionType);
             record[column] = formatPreference(record[column], exerciseData.locationQuestionType);
           } 
-          if (column == 'jurisdictionPreferences') {
+          if (column === 'jurisdictionPreferences') {
             record[column] = formatPreference(record[column], exerciseData.jurisdictionQuestionType);
           } 
         }

--- a/functions/actions/users.js
+++ b/functions/actions/users.js
@@ -25,7 +25,7 @@ module.exports = (auth, db) => {
       };
       console.log('generateSignInWithEmailLink', ref);
       const emailLink = await auth.generateSignInWithEmailLink(email, actionCodeSettings);
-      console.log('generateSignInWithEmailLink DONE', ref, emailLink);
+      console.log('generateSignInWithEmailLink DONE', ref);
       return emailLink;
     }
   }

--- a/functions/actions/users.js
+++ b/functions/actions/users.js
@@ -25,7 +25,7 @@ module.exports = (auth, db) => {
       };
       console.log('generateSignInWithEmailLink', ref);
       const emailLink = await auth.generateSignInWithEmailLink(email, actionCodeSettings);
-      console.log('generateSignInWithEmailLink DONE', ref);
+      console.log('generateSignInWithEmailLink DONE', ref, emailLink);
       return emailLink;
     }
   }

--- a/functions/callableFunctions/resetAssessments.js
+++ b/functions/callableFunctions/resetAssessments.js
@@ -2,7 +2,7 @@ const functions = require('firebase-functions');
 const config = require('../shared/config');
 const { firebase, db } = require('../shared/admin.js');
 const { checkArguments } = require('../shared/helpers.js');
-const { cancelAssessments } = require('../actions/assessments')(config, firebase, db);
+const { resetAssessments } = require('../actions/assessments')(config, firebase, db);
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 const { PERMISSIONS, hasPermissions } = require('../shared/permissions');
 
@@ -21,11 +21,15 @@ module.exports = functions.region('europe-west2').https.onCall(async (data, cont
   if (!checkArguments({
     exerciseId: { required: true },
     assessmentIds: { required: false },
-    cancelReason: { required: false },
+    status: { required: false },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
   }
-  const result = await cancelAssessments(data);
+  const result = await resetAssessments({
+    exerciseId: data.exerciseId,
+    assessmentIds: data.assessmentIds,
+    status: data.status ? data.status : 'draft',
+  });
   return {
     result: result,
   };

--- a/functions/callableFunctions/testAssessmentNotification.js
+++ b/functions/callableFunctions/testAssessmentNotification.js
@@ -17,13 +17,13 @@ module.exports = functions.region('europe-west2').https.onCall(async (data, cont
   ]);
 
   if (!checkArguments({
-    assessmentId: { required: true },
+    assessmentIds: { required: true },
     notificationType: { required: true },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
   }
   const result = await testAssessmentNotification({
-    assessmentId: data.assessmentId,
+    assessmentIds: data.assessmentIds,
     notificationType: data.notificationType,
     email: context.auth.token.email,
   });

--- a/functions/index.js
+++ b/functions/index.js
@@ -26,6 +26,7 @@ exports.generateOutreachReport = require('./callableFunctions/generateOutreachRe
 exports.flagApplicationIssuesForExercise = require('./callableFunctions/flagApplicationIssuesForExercise');
 exports.initialiseAssessments = require('./callableFunctions/initialiseAssessments');
 exports.cancelAssessments = require('./callableFunctions/cancelAssessments');
+exports.resetAssessments = require('./callableFunctions/resetAssessments');
 exports.testAssessmentNotification = require('./callableFunctions/testAssessmentNotification');
 exports.sendAssessmentRequests = require('./callableFunctions/sendAssessmentRequests');
 exports.sendAssessmentReminders = require('./callableFunctions/sendAssessmentReminders');

--- a/functions/shared/factories.js
+++ b/functions/shared/factories.js
@@ -4,6 +4,7 @@ module.exports = (CONSTANTS) => {
     newNotificationCharacterCheckRequest,
     newNotificationAssessmentRequest,
     newNotificationAssessmentReminder,
+    newNotificationAssessmentSubmit,
     newAssessment,
     newApplicationRecord,
     newVacancy,
@@ -127,6 +128,47 @@ module.exports = (CONSTANTS) => {
       status: 'ready',
     };
   }
+
+  function newNotificationAssessmentSubmit(firebase, assessment) {
+    const link = `${CONSTANTS.ASSESSMENTS_URL}/sign-in?email=${assessment.assessor.email}&ref=assessments/${assessment.id}`;
+    let xCompetencyAreasOrXSkillsAndAbilities;
+    switch (assessment.type) {
+      case CONSTANTS.ASSESSMENT_TYPE.COMPETENCY:
+        xCompetencyAreasOrXSkillsAndAbilities = 'competency areas';
+        break;
+      case CONSTANTS.ASSESSMENT_TYPE.SKILLS:
+        xCompetencyAreasOrXSkillsAndAbilities = 'skills and abilities';
+        break;
+      default:
+        xCompetencyAreasOrXSkillsAndAbilities = 'requirements';
+    }
+    return {
+      email: assessment.assessor.email,
+      replyTo: assessment.exercise.exerciseMailbox,
+      template: {
+        name: 'Assessment Submit',
+        id: '5b933b71-3359-488a-aa86-13ceb581209c',
+      },
+      personalisation: {
+        assessorName: assessment.assessor.fullName,
+        applicantName: assessment.candidate.fullName,
+        exerciseName: assessment.exercise.name,
+        xCompetencyAreasOrXSkillsAndAbilities: xCompetencyAreasOrXSkillsAndAbilities,
+        submitAssessmentDueDate: assessment.dueDate.toDate().toLocaleDateString('en-GB', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }),
+        uploadUrl: link,
+        downloadUrl: link,
+        exerciseMailbox: assessment.exercise.exerciseMailbox,
+        exercisePhoneNumber: assessment.exercise.exercisePhoneNumber,
+        selectionExerciseManager: assessment.exercise.emailSignatureName,
+      },
+      reference: {
+        collection: 'assessments',
+        id: assessment.id,
+      },
+      createdAt: firebase.firestore.Timestamp.fromDate(new Date()),
+      status: 'ready',
+    };
+  }  
 
   function newAssessment(exercise, application, whichAssessor) {
     let assessment = {

--- a/functions/shared/factories.js
+++ b/functions/shared/factories.js
@@ -157,10 +157,12 @@ module.exports = (CONSTANTS) => {
     }
     switch (whichAssessor) {
       case 'first':
+        assessment.assessor.type = application.firstAssessorType ? application.firstAssessorType : '';
         assessment.assessor.fullName = application.firstAssessorFullName ? application.firstAssessorFullName : '';
         assessment.assessor.email = application.firstAssessorEmail ? application.firstAssessorEmail : '';
         break;
       case 'second':
+        assessment.assessor.type = application.secondAssessorType ? application.secondAssessorType : '';
         assessment.assessor.fullName = application.secondAssessorFullName ? application.secondAssessorFullName : '';
         assessment.assessor.email = application.secondAssessorEmail ? application.secondAssessorEmail : '';
         break;


### PR DESCRIPTION
## What's included?
1. Add **assessor type** when create a new assessment.
2. Add `resetAssessment` to change assessment status.
3. Update parameters passed into `cancelAssessment` and `testAssessmentNotification`.
4. Update Firestore index to support assessor type filter.
5. Update Firestore rules to allow update assessment status.
6. Send submit notification when assessments are completed.

Note: this PR is related to [#1690 Update independent assessments UI](https://github.com/jac-uk/admin/pull/1696).

## Who should test?
✅ Developers

## How to test?
1. Run functions locally.
2. On admin site, check out branch `feature/1690-update-independent-assessments-ui`.
3. Follow the test steps in this PR [#1690 Update independent assessments UI](https://github.com/jac-uk/admin/pull/1696).

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context


## Related permissions
- No permission changes required

