### PR TITLE
Bugfix/Emp-flag-QT-init

### DIFF
--- a/functions/actions/qualifyingTests/initialiseQualifyingTest.js
+++ b/functions/actions/qualifyingTests/initialiseQualifyingTest.js
@@ -34,7 +34,7 @@ module.exports = (config, firebase, db) => {
         applicationRecordsRef = applicationRecordsRef.where('status', '==', params.status);
       }
       if (qualifyingTest.isTieBreaker) { // for EMP tie-breaker tests, only include EMP candidates
-        applicationRecordsRef = applicationRecordsRef.where('flags.empApplied', '==', true);
+        applicationRecordsRef = applicationRecordsRef.where('flags.empApplied', 'in', [ true, 'gender', 'ethnicity' ]);
       }
 
       participants = await getDocuments(applicationRecordsRef);


### PR DESCRIPTION
EMP flag was assumed to be `Boolean` but after recent update can also be `'gender'` or `'ethnicity'`  
Due to this EMP candidates couldnt be added to QTs.