### PR TITLE
#769 Hotfix: Handover report should include diversity

### DIFF
--- a/functions/actions/exercises/generateHandoverReport.js
+++ b/functions/actions/exercises/generateHandoverReport.js
@@ -117,6 +117,10 @@ const reportHeaders = (exercise) => {
     reportHeaders.push(...headers.diversity.common);
   }
 
+  if (exercise.typeOfExercise === 'leadership-non-legal') {
+    reportHeaders.push(...headers.diversity.common);
+  }
+
   reportHeaders.push(
     { title: 'Location Preferences', ref: 'locationPreferences' },
     { title: 'Jurisdiction Preferences', ref: 'jurisdictionPreferences' },
@@ -267,7 +271,7 @@ const formatLegalData = (application) => {
       ].join(' ');
     }).join('\n');
   }
-  
+
   let judicialExperience;
   if (application.feePaidOrSalariedJudge) {
     judicialExperience = `Fee paid or salaried judge - ${lookup(application.feePaidOrSalariedSittingDaysDetails)} days`;

--- a/nodeScripts/generateHandoverReport.js
+++ b/nodeScripts/generateHandoverReport.js
@@ -4,7 +4,7 @@ const { firebase, app, db } = require('./shared/admin.js');
 const { generateHandoverReport } = require('../functions/actions/exercises/generateHandoverReport')(firebase, db);
 
 const main = async () => {
-  return generateHandoverReport('Yt04PxbBde5nfZxNgFWx');
+  return generateHandoverReport('DqKdMSMOmxArSWYsDyhZ');
 };
 
 main()


### PR DESCRIPTION
See #769 for more details
Closes #769

Handover report is missing diversity columns for leadership non legal exercises. This PR fixes it.