### PR TITLE
#760 TimeLine Update in Apply (sift and name blind sift date)

### DIFF
--- a/functions/shared/factories.js
+++ b/functions/shared/factories.js
@@ -369,6 +369,8 @@ module.exports = (CONSTANTS) => {
       selectionDays: null,
       selectionExerciseManagerFullName: null,
       shortlistingMethods: null,
+      siftStartDate: null,
+      siftEndDate: null,
       nameBlindSiftStartDate: null,
       nameBlindSiftEndDate: null,
       shortlistingOutcomeDate: null,

--- a/functions/shared/factories.js
+++ b/functions/shared/factories.js
@@ -369,6 +369,8 @@ module.exports = (CONSTANTS) => {
       selectionDays: null,
       selectionExerciseManagerFullName: null,
       shortlistingMethods: null,
+      nameBlindSiftStartDate: null,
+      nameBlindSiftEndDate: null,
       shortlistingOutcomeDate: null,
       situationalJudgementTestDate: null,
       situationalJudgementTestEndTime: null,


### PR DESCRIPTION
## What's included?
Add the missing sift information to vacancy model.
- siftStartDate
- siftEndDate
- nameBlindSiftStartDate
- nameBlindSiftEndDate

## Who should test?
✅ Developers

## How to test?
Update name blind sift date of an exercise on admin and check if it shows the right start and end date on apply.  

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Related permissions
- No permission changes required

---
PREVIEW:DEVELOP
