### PR TITLE
Bugfix: Initialise QT. Exclude withdrawn candidates

### DIFF
--- a/functions/actions/qualifyingTests/initialiseQualifyingTest.js
+++ b/functions/actions/qualifyingTests/initialiseQualifyingTest.js
@@ -30,13 +30,14 @@ module.exports = (config, firebase, db) => {
       let applicationRecordsRef = db.collection('applicationRecords')
         .where('exercise.id', '==', qualifyingTest.vacancy.id)
         .where('stage', '==', params.stage);
-      if (params.status !== 'all') {
+      if (params.status === 'all') {
+        applicationRecordsRef = applicationRecordsRef.where('status', '!=', 'withdrewApplication');
+      } else {
         applicationRecordsRef = applicationRecordsRef.where('status', '==', params.status);
       }
       if (qualifyingTest.isTieBreaker) { // for EMP tie-breaker tests, only include EMP candidates
         applicationRecordsRef = applicationRecordsRef.where('flags.empApplied', 'in', [ true, 'gender', 'ethnicity' ]);
       }
-
       participants = await getDocuments(applicationRecordsRef);
     }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "deploy:realtime-rules": "firebase deploy --project=digital-platform-develop --only database",
     "staging:deploy:rules": "firebase deploy --project=digital-platform-staging --only firestore:rules",
     "staging:deploy:indexes": "firebase deploy --project=digital-platform-staging --only firestore:indexes",
-    "staging:deploy:functions": "firebase deploy --project=digital-platform-staging --only functions",
+    "staging:deploy:functions": "firebase deploy --project=digital-platform-staging --only functions --force",
     "staging:deploy:function": "run(){ firebase deploy --project=digital-platform-staging --only functions:$1; }; run",
     "staging:deploy:storage-rules": "firebase deploy --project=digital-platform-staging --only storage:rules",
     "staging:deploy:realtime-rules": "firebase deploy --project=digital-platform-staging --only database",


### PR DESCRIPTION
This fix ensures withdrawn candidates are not included when initialising a Qualifying Test.

Also includes the `--force` flag when deploying functions to staging to ensure any functions not in our code base are removed.