### PR TITLE
Hotfix 1.29.1: Activate QT. Include dates when opening tests

### DIFF
--- a/functions/actions/qualifyingTests/activateQualifyingTest.js
+++ b/functions/actions/qualifyingTests/activateQualifyingTest.js
@@ -41,6 +41,8 @@ module.exports = (config, firebase, db) => {
           'testQuestions': questions,
           'qualifyingTest.additionalInstructions': qualifyingTest.additionalInstructions,
           'qualifyingTest.feedbackSurvey': qualifyingTest.feedbackSurvey,
+          'qualifyingTest.startDate': qualifyingTest.startDate,
+          'qualifyingTest.endDate': qualifyingTest.endDate,
           status: config.QUALIFYING_TEST_RESPONSES.STATUS.ACTIVATED,
           'statusLog.activated': firebase.firestore.FieldValue.serverTimestamp(),
           lastUpdated: firebase.firestore.FieldValue.serverTimestamp(),


### PR DESCRIPTION
This fix ensures that start and end dates are copied across to each `qualifyingTestResponse` when activating a Qualifying Test.
So that any changes to dates & times are brought across to the tests.

Note: this a hotfix and we will deploy directly from this branch, as well as merge into `develop`, when it has been approved.