### PR TITLE
#786 Migrate qualification complete field in application collection

### DIFF
--- a/functions/shared/converters/applicationConverter.js
+++ b/functions/shared/converters/applicationConverter.js
@@ -150,7 +150,7 @@ module.exports = () => {
           addField(data, 'Date qualified', formatDate(q.date));
         }
       }
-      if (q.qualificationNotComplete && q.details) {
+      if (!q.qualificationComplete && q.details) {
         addField(data, 'Completed pupillage', 'No');
         addField(data, 'Did not complete pupillage notes', q.details);
       }

--- a/functions/shared/converters/applicationConverter.js
+++ b/functions/shared/converters/applicationConverter.js
@@ -150,7 +150,7 @@ module.exports = () => {
           addField(data, 'Date qualified', formatDate(q.date));
         }
       }
-      if (!q.qualificationComplete && q.details) {
+      if (!q.completedPupillage && q.details) {
         addField(data, 'Completed pupillage', 'No');
         addField(data, 'Did not complete pupillage notes', q.details);
       }

--- a/nodeScripts/migrateQualificationComplete.js
+++ b/nodeScripts/migrateQualificationComplete.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const { app, db } = require('./shared/admin.js');
+const { applyUpdates, getDocuments } = require('../functions/shared/helpers');
+
+// whether to make changes in firestore
+const isAction = false;
+
+const main = async () => {
+  // get all applications with `qualificationNotComplete` field
+  // TODO: optimize query
+  const applications = await getDocuments(db.collection('applications').where('exerciseId', '==', 'kqgMVYmxlp5EkNpEiB3K'));
+
+  const commands = [];
+  const applicationIds = [];
+  for (let i = 0; i < applications.length; i++) {
+    const application = applications[i];
+    let isUpdate = false;
+
+    if (application.qualifications && application.qualifications.length) {
+      application.qualifications.forEach(qualification => {
+        // only migrate if `qualificationNotComplete` property is present in qualification
+        if ('qualificationNotComplete' in qualification) {
+          qualification.qualificationComplete = !qualification.qualificationNotComplete;
+          isUpdate = true;
+        }
+      });
+    }
+
+    if (isUpdate) {
+      commands.push({
+        command: 'update',
+        ref: application.ref,
+        data: application,
+      });
+      applicationIds.push(application.id);
+    }
+  }
+
+
+  const result = {
+    success: true,
+    total: applicationIds.length,
+    applicationIds,
+  };
+
+  if (commands.length) {
+    // write to db
+    const res = isAction ? await applyUpdates(db, commands) : commands.length;
+    result.success = (res === commands.length);
+  }
+
+  return result;
+};
+
+main()
+  .then((result) => {
+    console.log(result);
+    app.delete();
+    return process.exit();
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit();
+  });

--- a/nodeScripts/migrateQualificationComplete.js
+++ b/nodeScripts/migrateQualificationComplete.js
@@ -21,6 +21,7 @@ const main = async () => {
       application.qualifications.forEach(qualification => {
         // only migrate if `qualificationNotComplete` property is present in qualification
         if ('qualificationNotComplete' in qualification) {
+          // create new field `qualificationComplete`
           qualification.qualificationComplete = !qualification.qualificationNotComplete;
           isUpdate = true;
         }
@@ -39,7 +40,7 @@ const main = async () => {
 
 
   const result = {
-    success: true,
+    success: null,
     total: applicationIds.length,
     applicationIds,
   };

--- a/nodeScripts/migrateQualificationComplete.js
+++ b/nodeScripts/migrateQualificationComplete.js
@@ -7,7 +7,7 @@ const { applyUpdates, getDocuments, getDocument } = require('../functions/shared
 // whether to make changes in `applications` collection in firestore
 // true:  make changes in `applications` collection
 // false: create a temporary collection `applications_temp` and verify the changes is as expected
-const isAction = true;
+const isAction = false;
 
 const main = async () => {
   // get all applications with `qualificationNotComplete` field
@@ -54,7 +54,7 @@ const main = async () => {
 
     if (!isAction) {
       // verify if changes is as expected
-      let verifyNum = 0
+      let verifyNum = 0;
       for (let i = 0; i < commands.length; i++) {
         const command = commands[i];
         const applicationId = command.data.id;

--- a/nodeScripts/query.js
+++ b/nodeScripts/query.js
@@ -29,7 +29,7 @@ function flattenQualifications(data) {
     return '';
   }
   return data.map((item) => {
-    if (item.type === 'barrister' && !item.qualificationComplete) {
+    if (item.type === 'barrister' && !item.completedPupillage) {
       return `${upperCase(item.type)}\n${item.details}`;
     } else {
       return `${upperCase(item.type)}\n${formatDate(item.date)}`;

--- a/nodeScripts/query.js
+++ b/nodeScripts/query.js
@@ -29,7 +29,7 @@ function flattenQualifications(data) {
     return '';
   }
   return data.map((item) => {
-    if (item.type === 'barrister' && item.qualificationNotComplete) {
+    if (item.type === 'barrister' && !item.qualificationComplete) {
       return `${upperCase(item.type)}\n${item.details}`;
     } else {
       return `${upperCase(item.type)}\n${formatDate(item.date)}`;


### PR DESCRIPTION
## What's included?
Use a new field `qualification.completedPupillage` in the application collection instead of `qualification.qualificationNotComplete` to mark if a candidate has completed the pupillage.

### Development plan:

1. Create a node script.
2. Query for the application documents which has `qualification.qualificationNotComplete` property.
3. Iterate the results.
4. Update each document with new field `qualification.completedPupillage` based on the opposite value of `qualification.qualificationNotComplete`.
5. Go through all JAC repositories and use `qualification.completedPupillage` instead of `qualification.qualificationNotComplete`.

**6. (Will not do) Delete `qualification.qualificationNotComplete` field.** 

## Who should test?
✅ Developers

## How to test?
1. Open file `nodeScripts/migrateQualificationComplete.js`.
2. Run `npm run nodeScript migrateQualificationComplete`.
3. Modify flag `isAction` to `true` to update changes in Firestore.
4. Run `npm run nodeScript migrateQualificationComplete`.

<img width="1009" alt="#786 Migrate qualification complete field in application collection" src="https://user-images.githubusercontent.com/79906532/202178702-22a17b58-29e9-45d2-98d2-d8c78599629e.png">

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas
