### PR TITLE
Increase memory of virus scanning function

### DIFF
--- a/functions/scheduledFunctions/scheduleScanAllFiles.js
+++ b/functions/scheduledFunctions/scheduleScanAllFiles.js
@@ -7,7 +7,7 @@ const { scanAllFiles } = require('../actions/malware-scanning/scanAllFiles')(con
 const SCHEDULE = 'every 1 hours'; // this setting is temporary
 const runtimeOptions = {
   timeoutSeconds: 540, // maximum value is 540
-  memory: '1GB',
+  memory: '4GB',
 };
 
 module.exports = functions.region('europe-west2')


### PR DESCRIPTION
## What's included?
Increase the memory of the schedule function `scheduleScanAllFiles` to `4GB`.

Error log:
<img width="967" alt="Screenshot 2022-11-25 at 12 54 26" src="https://user-images.githubusercontent.com/79906532/203990217-ba38896f-57ca-4697-b9dd-a8028b33a44a.png">

