### PR TITLE
Bugfix: character check consent form submit

### DIFF
--- a/functions/shared/factories.js
+++ b/functions/shared/factories.js
@@ -46,7 +46,7 @@ module.exports = (CONSTANTS) => {
       templateId = '5a4e7cbb-ab66-49a4-a8ad-7cbb399a8aa9';
       templateName = 'Character check consent form request';
     } else if (type === 'submit') {
-      templateId = '39b1326a-ee82-4fad-a6a6-79fc156974f1';
+      templateId = 'a434c479-2002-492f-94b5-d9c1f1a7c85c';
       templateName = 'Character check consent form submit';
     } else {
       templateId = '163487cb-f4c6-4b7a-95bf-37fd958a14de';


### PR DESCRIPTION
## What's included?
For some reason the email template of character check submit is not there. I have created a new one for it and update the template id in this PR. 

The email template:

<img width="678" alt="Screenshot 2022-12-06 at 13 19 46" src="https://user-images.githubusercontent.com/79906532/205926126-597e2614-fd84-4b9e-939b-546a85745d70.png">

## How to test?
1. [apply] Complete the character checks and submit the form.
2. [admin] Check the notification is in the queue.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

