### PR TITLE
Generate statutory consultation report

### DIFF
--- a/JAC - Digital Platform.postman_collection.json
+++ b/JAC - Digital Platform.postman_collection.json
@@ -531,6 +531,43 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Generate Statutory Consultation Report",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"data\": {\r\n        \"exerciseId\": \"kJKbG9TOQToEzB4AlEV1\"\r\n    }\r\n}"
+						},
+						"url": {
+							"raw": "{{host}}/generateStatutoryConsultationReport",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"generateStatutoryConsultationReport"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},

--- a/functions/actions/exercises/generateStatutoryConsultationReport.js
+++ b/functions/actions/exercises/generateStatutoryConsultationReport.js
@@ -140,8 +140,9 @@ function getQualificationData(qualifications) {
     data[`qualificationLocation${index}`] = lookup(qualification.location) || '';
     data[`qualificationDate${index}`] = formatDate(qualification.date) || '';
     data[`completedPupillage${index}`] = helpers.toYesNo(qualification.completedPupillage) || '';
-    data[`notCompletePupillageReason${index}`] =
-      qualification.notCompletePupillageReason !== NOT_COMPLETE_PUPILLAGE_REASONS.OTHER ? lookup(qualification.notCompletePupillageReason) : qualification.details;
+    data[`notCompletePupillageReason${index}`] = qualification.completedPupillage ? '' : (
+      qualification.notCompletePupillageReason !== NOT_COMPLETE_PUPILLAGE_REASONS.OTHER ? lookup(qualification.notCompletePupillageReason) : qualification.details
+    );
   }
   return data;
 }
@@ -151,9 +152,13 @@ function getExperienceData(experiences) {
   for (let i = 0; i < experiences.length; i++) {
     const experience = experiences[i];
     const index = i + 1;
+    const dates = [];
+    if (experience.startDate) dates.push(formatDate(experience.startDate));
+    if (experience.endDate) dates.push(formatDate(experience.endDate));
+
     data[`orgBusinessName${index}`] = experience.orgBusinessName || '';
     data[`jobTitle${index}`] = experience.jobTitle || '';
-    data[`experienceDates${index}`] = `${formatDate(experience.startDate)} - ${formatDate(experience.endDate)}` || '';
+    data[`experienceDates${index}`] = dates.join(' - ');
     data[`experienceLocation${index}`] = experience.taskDetails && experience.taskDetails.location ? experience.taskDetails.location : '';
     data[`jurisdiction${index}`] = experience.taskDetails && experience.taskDetails.jurisdiction ? experience.taskDetails.jurisdiction : '';
   }

--- a/functions/actions/exercises/generateStatutoryConsultationReport.js
+++ b/functions/actions/exercises/generateStatutoryConsultationReport.js
@@ -139,7 +139,7 @@ function getQualificationData(qualifications) {
     const index = i + 1;
     data[`qualificationType${index}`] = lookup(qualification.type) || '';
     data[`qualificationLocation${index}`] = lookup(qualification.location) || '';
-    data[`qualificationDate${index}`] = formatDate(qualification.date) || '';
+    data[`qualificationDate${index}`] = formatDate(qualification.date, 'DD/MM/YYYY') || '';
     data[`completedPupillage${index}`] = helpers.toYesNo(qualification.completedPupillage) || '';
     data[`notCompletePupillageReason${index}`] = qualification.completedPupillage ? '' : (
       qualification.notCompletePupillageReason !== NOT_COMPLETE_PUPILLAGE_REASONS.OTHER ? lookup(qualification.notCompletePupillageReason) : qualification.details
@@ -154,8 +154,8 @@ function getExperienceData(experiences) {
     const experience = experiences[i];
     const index = i + 1;
     const dates = [];
-    if (experience.startDate) dates.push(formatDate(experience.startDate));
-    if (experience.endDate) dates.push(formatDate(experience.endDate));
+    if (experience.startDate) dates.push(formatDate(experience.startDate, 'DD/MM/YYYY'));
+    if (experience.endDate) dates.push(formatDate(experience.endDate, 'DD/MM/YYYY'));
 
     data[`orgBusinessName${index}`] = experience.orgBusinessName || '';
     data[`jobTitle${index}`] = experience.jobTitle || '';

--- a/functions/actions/exercises/generateStatutoryConsultationReport.js
+++ b/functions/actions/exercises/generateStatutoryConsultationReport.js
@@ -141,11 +141,22 @@ function getQualificationData(qualifications) {
     data[`qualificationLocation${index}`] = lookup(qualification.location) || '';
     data[`qualificationDate${index}`] = formatDate(qualification.date, 'DD/MM/YYYY') || '';
     data[`completedPupillage${index}`] = helpers.toYesNo(qualification.completedPupillage) || '';
-    data[`notCompletePupillageReason${index}`] = qualification.completedPupillage ? '' : (
-      qualification.notCompletePupillageReason !== NOT_COMPLETE_PUPILLAGE_REASONS.OTHER ? lookup(qualification.notCompletePupillageReason) : qualification.details
-    );
+    data[`notCompletePupillageReason${index}`] = getNotCompletePupillageReason(qualification);
   }
   return data;
+}
+
+function getNotCompletePupillageReason(qualification) {
+  if (qualification.completedPupillage)
+    return '';
+  else if (qualification.notCompletePupillageReason === NOT_COMPLETE_PUPILLAGE_REASONS.TRANSFERRED)
+    return lookup(NOT_COMPLETE_PUPILLAGE_REASONS.TRANSFERRED);
+  else if (qualification.notCompletePupillageReason === NOT_COMPLETE_PUPILLAGE_REASONS.CALLED_PRE_2002)
+    return lookup(NOT_COMPLETE_PUPILLAGE_REASONS.CALLED_PRE_2002);
+  else if (qualification.details)
+    return qualification.details;
+  else
+    return '';
 }
 
 function getExperienceData(experiences) {

--- a/functions/actions/exercises/generateStatutoryConsultationReport.js
+++ b/functions/actions/exercises/generateStatutoryConsultationReport.js
@@ -12,7 +12,7 @@ module.exports = (firebase, db) => {
     // get submitted application with invited to selection day
     const applicationRecords = await getDocuments(db.collection('applicationRecords')
       .where('exercise.id', '==', exerciseId)
-      .where('stage', 'in', ['review', 'shortlisted', 'selected', 'recommended', 'handover'])
+      .where('status', '==', 'invitedToSelectionDay')
     );
     const applicationIds = applicationRecords.map(item => item.id);
     const applicationRefs = applicationIds.map(id => db.collection('applications').doc(id));

--- a/functions/actions/exercises/generateStatutoryConsultationReport.js
+++ b/functions/actions/exercises/generateStatutoryConsultationReport.js
@@ -12,7 +12,7 @@ module.exports = (firebase, db) => {
     // get submitted application with invited to selection day
     const applicationRecords = await getDocuments(db.collection('applicationRecords')
       .where('exercise.id', '==', exerciseId)
-      .where('stage', '==', 'selected')
+      .where('stage', 'in', ['review', 'shortlisted', 'selected', 'recommended', 'handover'])
     );
     const applicationIds = applicationRecords.map(item => item.id);
     const applicationRefs = applicationIds.map(id => db.collection('applications').doc(id));

--- a/functions/actions/exercises/generateStatutoryConsultationReport.js
+++ b/functions/actions/exercises/generateStatutoryConsultationReport.js
@@ -1,0 +1,119 @@
+const { getDocument, getDocuments } = require('../../shared/helpers');
+const lookup = require('../../shared/converters/lookup');
+const helpers = require('../../shared/converters/helpers');
+
+module.exports = (firebase, db) => {
+  return {
+    generateStatutoryConsultationReport,
+  };
+
+  async function generateStatutoryConsultationReport(exerciseId) {
+    const exercise = await getDocument(db.collection('exercises').doc(exerciseId));
+
+    // get submitted applications
+    const applications = await getDocuments(db.collection('applications')
+      .where('exerciseId', '==', exerciseId)
+      .where('status', 'in', ['applied'])
+    );
+
+    // get report headers
+    const headers = reportHeaders(exercise);
+
+    // get report rows
+    const rows = reportData(db, exercise, applications);
+
+    // construct the report document
+    const report = {
+      totalApplications: applications.length,
+      createdAt: firebase.firestore.Timestamp.fromDate(new Date()),
+      headers,
+      rows,
+    };
+
+    // store the report document in the database
+    await db.collection('exercises').doc(exerciseId).collection('reports').doc('statutoryConsultation').set(report);
+
+    // return the report in the HTTP response
+    return report;
+  }
+};
+
+/**
+ * Get the report headers
+ * 
+ * @param {document} exercise
+ * @return {array}
+ */
+const reportHeaders = (exercise) => {
+  const headers = [
+    { title: 'First name', ref: 'firstName' },
+    { title: 'Last name', ref: 'lastName' },
+    { title: 'Suffix', ref: 'suffix' },
+  ];
+
+  return headers;
+};
+
+/**
+ * Get the report data
+ *
+ * @param {db} db
+ * @param {document} exercise
+ * @param {array} applications
+ * @returns {array}
+ */
+const reportData = (db, exercise, applications) => {
+  return applications.map((application) => {
+    const personalDetails = application.personalDetails || {}; 
+    const qualifications = application.qualifications || [];
+
+    let firstName = personalDetails.firstName;
+    let lastName = personalDetails.lastName;
+    let fullName = personalDetails.fullName;
+    if (!firstName && !lastName && fullName) {
+      const names = fullName.split(' ');
+      if (names.length > 1) {
+        firstName = names.shift();
+      }
+      lastName = names.join(' ');
+    }
+
+    return {
+      firstName: firstName || null,
+      lastName: lastName || null,
+      suffix: personalDetails.suffix || null,
+      qualifications: getFormattedQualifications(qualifications),
+      qualificationsDates: getFormattedQualificationsDates(qualifications),
+    };
+  });
+
+  /**
+   * Get formatted qualifications without date
+   * 
+   * @param {object} qualifications
+   * @return {string}
+   */
+  function getFormattedQualifications(qualifications) {
+    return qualifications.map(qualification => {
+      return [
+        lookup(qualification.location),
+        lookup(qualification.type),
+        qualification.membershipNumber,
+      ].join(' ');
+    }).join('\n');
+  }
+
+  /**
+   * Get formatted dates of qualifications
+   * 
+   * @param {object} qualifications
+   * @return {string}
+   */
+  function getFormattedQualificationsDates(qualifications) {
+    return qualifications.map(qualification => {
+      return [
+        helpers.formatDate(qualification.date),
+      ].join(' ');
+    }).join('\n');
+  }
+};

--- a/functions/callableFunctions/generateStatutoryConsultationReport.js
+++ b/functions/callableFunctions/generateStatutoryConsultationReport.js
@@ -1,0 +1,50 @@
+const functions = require('firebase-functions');
+const { firebase, db, auth } = require('../shared/admin.js');
+const { checkArguments } = require('../shared/helpers.js');
+const { generateStatutoryConsultationReport } = require('../actions/exercises/generateStatutoryConsultationReport')(firebase, db);
+const { getDocument } = require('../shared/helpers');
+const { logEvent } = require('../actions/logs/logEvent')(firebase, db, auth);
+const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
+const { PERMISSIONS, hasPermissions } = require('../shared/permissions');
+
+module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
+  await checkFunctionEnabled();
+
+  // authenticate the request
+  if (!context.auth) {
+    throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');
+  }
+
+  hasPermissions(context.auth.token.rp, [
+    PERMISSIONS.applications.permissions.canReadApplications.value,
+    PERMISSIONS.applicationRecords.permissions.canReadApplicationRecords.value,
+    PERMISSIONS.exercises.permissions.canReadExercises.value,
+  ]);
+
+  // validate input parameters
+  if (!checkArguments({
+    exerciseId: { required: true },
+  }, data)) {
+    throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
+  }
+
+  // generate the report
+  const result = await generateStatutoryConsultationReport(data.exerciseId);
+
+  // log an event
+  const exercise = await getDocument(db.collection('exercises').doc(data.exerciseId));
+  let details = {
+    exerciseId: exercise.id,
+    exerciseRef: exercise.referenceNumber,
+  };
+  let user = {
+    id: context.auth.token.user_id,
+    name: context.auth.token.name,
+  };
+  await logEvent('info', 'Outreach report generated', details, user);
+
+  // return the report to the caller
+  return {
+    result: result,
+  };
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -52,6 +52,7 @@ exports.generateHandoverReport = require('./callableFunctions/generateHandoverRe
 exports.generateReasonableAdjustmentsReport = require('./callableFunctions/generateReasonableAdjustmentsReport');
 exports.exportQualifyingTestResponses = require('./callableFunctions/exportQualifyingTestResponses');
 exports.generateAgencyReport = require('./callableFunctions/generateAgencyReport');
+exports.generateStatutoryConsultationReport = require('./callableFunctions/generateStatutoryConsultationReport');
 exports.logEvent = require('./callableFunctions/logEvent');
 exports.scanFile = require('./callableFunctions/scanFile');
 exports.scanAllFiles = require('./callableFunctions/scanAllFiles');

--- a/functions/shared/config.js
+++ b/functions/shared/config.js
@@ -308,4 +308,9 @@ module.exports = {
   SCAN_SERVICE_URL: functions.config().scan_service.url,
   GOOGLE_RECAPTCHA_VALIDATION_URL: functions.config().google_recaptcha.url,
   GOOGLE_RECAPTCHA_SECRET: functions.config().google_recaptcha.secret,
+  NOT_COMPLETE_PUPILLAGE_REASONS: {
+    TRANSFERRED: 'transferred ',
+    CALLED_PRE_2002: 'called-pre-2002',
+    OTHER: 'other',
+  },
 };

--- a/functions/shared/converters/lookup.js
+++ b/functions/shared/converters/lookup.js
@@ -210,7 +210,6 @@ const lookup = (value) => {
 
     lookup[NOT_COMPLETE_PUPILLAGE_REASONS.TRANSFERRED] = 'Qualified solicitor, qualified lawyer from another jurisdiction, or a legal academic transferred to the Bar';
     lookup[NOT_COMPLETE_PUPILLAGE_REASONS.CALLED_PRE_2002] = 'Called to the Bar prior to 1 January 2002';
-    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.OTHER] = 'Other - Please detail why you were exempt from undertaking pupillage by the Bar Standards Board';
 
     return lookup[value] || value;
   }

--- a/functions/shared/converters/lookup.js
+++ b/functions/shared/converters/lookup.js
@@ -1,3 +1,5 @@
+const { NOT_COMPLETE_PUPILLAGE_REASONS } = require('../config');
+
 const lookup = (value) => {
   if (typeof value === 'string') {
     // @TODO: extract lookup values
@@ -205,6 +207,10 @@ const lookup = (value) => {
       /* ApplicationRecords statuses: end */
       // 'xxx': 'xxx',`
     };
+
+    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.TRANSFERRED] = 'Qualified solicitor, qualified lawyer from another jurisdiction, or a legal academic transferred to the Bar';
+    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.CALLED_PRE_2002] = 'Called to the Bar prior to 1 January 2002';
+    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.OTHER] = 'Other - Please detail why you were exempt from undertaking pupillage by the Bar Standards Board';
 
     return lookup[value] || value;
   }

--- a/functions/shared/helpers.js
+++ b/functions/shared/helpers.js
@@ -215,6 +215,10 @@ function formatDate(value, type) {
       case 'time':
         value = toTimeString(value);
         break;
+      case 'DD/MM/YYYY':
+        // e.g. 30/11/2022 (ref: https://momentjs.com/docs/#/displaying/format/)
+        value = value.toLocaleDateString();
+        break;
       case 'date-hour-minute':
         // e.g. Wednesday, 30 November, 2022 at 13:00
         value = `${value.toLocaleDateString('en-GB', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })} at ${value.toLocaleTimeString('en-GB', { hour: '2-digit', minute:'2-digit', hour12: false })}`;

--- a/nodeScripts/generateStatutoryConsultationReport.js
+++ b/nodeScripts/generateStatutoryConsultationReport.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const { firebase, app, db } = require('./shared/admin.js');
+const { generateStatutoryConsultationReport } = require('../functions/actions/exercises/generateStatutoryConsultationReport')(firebase, db);
+
+const main = async () => {
+  return generateStatutoryConsultationReport('kJKbG9TOQToEzB4AlEV1');
+};
+
+main()
+  .then((result) => {
+    console.log(result);
+    app.delete();
+    return process.exit();
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit();
+  });


### PR DESCRIPTION
## What's included?
Add a callable function `generateStatutoryConsultationReport` to populate the statutory consultation report from the applications invited to the selection day.

## Who should test?
✅ Developers

## How to test?
Run the node script: `npm run nodeScript generateStatutoryConsultationReport`

