### PR TITLE
#784 QT Responses download should include 'half answered' SJ answers

### DIFF
--- a/functions/actions/qualifyingTestResponses/export.js
+++ b/functions/actions/qualifyingTestResponses/export.js
@@ -97,31 +97,16 @@ const getData = (qualifyingTest, qualifyingTestResponses) => {
             response = element.testQuestions.questions[index].response;
           }
         }
-        if (response) {
+        if (response && response.selection) {
           const responseSelection = response.selection;
-          if (responseSelection) {
-            if ((responseSelection.mostAppropriate !== undefined && responseSelection.mostAppropriate !== null)
-              && (responseSelection.leastAppropriate !== undefined && responseSelection.leastAppropriate !== null))
-            {
-              row.push(
-                question.options[responseSelection.mostAppropriate].answer,
-                question.options[responseSelection.leastAppropriate].answer,
-                response.score
-              );
-            } else {
-              row.push(
-                '---',
-                '---',
-                '---'
-              );
-            }
-          } else {
-            row.push(
-              '---',
-              '---',
-              '---'
-            );
-          }
+          const mostAppropriate = responseSelection.mostAppropriate !== undefined && responseSelection.mostAppropriate !== null ? question.options[responseSelection.mostAppropriate].answer : '---';
+          const leastAppropriate = responseSelection.leastAppropriate !== undefined && responseSelection.leastAppropriate !== null ? question.options[responseSelection.leastAppropriate].answer : '---';
+          const score = response.score ? response.score : 0;
+          row.push(
+            mostAppropriate,
+            leastAppropriate,
+            score
+          );
         } else {
           row.push(
             '---',


### PR DESCRIPTION
Includes half-answered questions in the responses download.
Closes #784 

**Before**
<img width="470" alt="image" src="https://user-images.githubusercontent.com/8524401/213242212-75adade8-f837-4d67-87f7-38add8103404.png">

**After**
<img width="465" alt="image" src="https://user-images.githubusercontent.com/8524401/213242274-0c9f53a8-fcd7-475d-838b-f3a50f73978f.png">

