### PR TITLE
Script to enable Justice.gov.uk users from Admin authentication

### DIFF
--- a/nodeScripts/tidyAuthUsers.js
+++ b/nodeScripts/tidyAuthUsers.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const { app, db } = require('./shared/admin');
+const { listAllUsers, deleteUser, log } = require('./shared/helpers');
+const { getDocument } = require('../functions/shared/helpers');
+
+// whether to make changes in authentication database
+const isAction = false;
+
+const main = async () => {
+  log('Get all users from authentication database...');
+  let users = await listAllUsers();
+  log(`Total users: ${users.length}`);
+
+  log('Filter users with email *@justice.gov.uk...');
+  const filteredUsers = users.filter(item =>
+    item.email.indexOf('@justice.gov.uk') > 0 &&
+    item.providerData.length === 1 &&
+    item.providerData[0].providerId === 'password'
+  );
+  log(`Total filtered users: ${filteredUsers.length}`);
+
+  log('Tidy up users...');
+  const result = [];
+  let count = 0;
+  for (let i = 0; i < filteredUsers.length; i++) {
+    const user = filteredUsers[i];
+    const isCandidate = await getDocument(db.collection('candidates').doc(user.uid));
+    if (isCandidate) {
+      if (isAction) {
+        await deleteUser(user.uid);
+      }
+      count++;
+      result.push(`${count}. ${user.uid}, ${user.email}`);
+    }
+  }
+  log('Tidy up users...done');
+
+  return result;
+};
+
+main()
+  .then((result) => {
+    console.log(result.join('\n'));
+    app.delete();
+    return process.exit();
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit();
+  });


### PR DESCRIPTION
## What's included? 
Write a script to loop through all Justice.gov.uk users and if their account is disabled (and it is email/password provider) then enable it

## Who should test?
✅ Developers

## How to test?
1. Open the file `nodeScripts/tidyAuthUsers.js`.
2. Run `npm run nodeScript tidyAuthUsers`.
3. Modify flag `isAction` to `true` to update changes in the authentication database.
4. Run `npm run nodeScript tidyAuthUsers`.

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas
