### PR TITLE
Admin#1910 Addition to Handover Report

### DIFF
--- a/functions/actions/exercises/generateHandoverReport.js
+++ b/functions/actions/exercises/generateHandoverReport.js
@@ -124,6 +124,13 @@ const reportHeaders = (exercise) => {
     reportHeaders.push(...headers.diversity.common);
   }
 
+  if (exercise.isSPTWOffered) {
+    reportHeaders.push(
+      { title: 'Part Time Working Preferences', ref: 'interestedInPartTime' },
+      { title: 'Part Time Working Preferences details', ref: 'partTimeWorkingPreferencesDetails' }
+    );
+  }
+
   reportHeaders.push(
     { title: 'Location Preferences', ref: 'locationPreferences' },
     { title: 'Jurisdiction Preferences', ref: 'jurisdictionPreferences' },
@@ -164,6 +171,10 @@ const reportData = (db, exercise, applicationRecords, applications) => {
       ? getAdditionalWorkingPreferences(application, exercise).map(x => `${removeHtml(x.label)}\n${removeHtml(x.value)}`).join('\n\n') : '';
     const welshPosts = exercise.welshRequirement
       ? getWelshData(application).map(x => `${removeHtml(x.label)}\n${removeHtml(x.value)}`).join('\n\n') : '';
+    const partTimeWorkingPreferences = {
+      interestedInPartTime: helpers.toYesNo(application.interestedInPartTime) || '',
+      partTimeWorkingPreferencesDetails: application.partTimeWorkingPreferencesDetails || '',
+    };
 
     // return report data for this application
     return {
@@ -178,6 +189,7 @@ const reportData = (db, exercise, applicationRecords, applications) => {
       jurisdictionPreferences,
       additionalPreferences,
       welshPosts,
+      ...partTimeWorkingPreferences,
     };
 
   });


### PR DESCRIPTION
## What's included?
Add part time working preferences to the handover report.

## Who should test?
✅ Product owner
✅ Developers

## How to test?
1. Go to admin on develop: https://admin-develop.judicialappointments.digital.
2. Find an exercise that offers salaried part-time working (SPTW).
3. Go to the Handover report and hit the Refresh button.
4. Export data and check if the answers to part time woking preferences are shown in the report.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/223075008-32638674-2cd8-45eb-a99d-12bb032381ee.mov

