### PR TITLE
#855 Support for QT mop ups being excluded from main test scoring

### DIFF
--- a/functions/actions/tasks/updateTask.js
+++ b/functions/actions/tasks/updateTask.js
@@ -620,12 +620,14 @@ module.exports = (config, firebase, db) => {
     // construct finalScores
     const finalScores = [];
     task.applications.forEach(application => {
-      finalScores.push({
-        id: application.id,
-        ref: application.ref,
-        score: response.scores[application.id],
-        percent: 100 * (response.scores[application.id] / response.maxScore),
-      });
+      if (response.scores[application.id]) {
+        finalScores.push({
+          id: application.id,
+          ref: application.ref,
+          score: response.scores[application.id],
+          percent: 100 * (response.scores[application.id] / response.maxScore),
+        });
+      }
     });
     result.success = true;
     result.data.maxScore = response.maxScore;

--- a/functions/actions/tasks/updateTask.js
+++ b/functions/actions/tasks/updateTask.js
@@ -687,9 +687,14 @@ module.exports = (config, firebase, db) => {
     outcomeStats[passStatus] = 0;
     outcomeStats[failStatus] = 0;
 
-    // update application records
+    // get applications still relevant to this task
+    const applications = await getApplications(exercise, task);
+    const applicationIdMap = {};
+    applications.forEach(application => applicationIdMap[application.id] = true);
+
+    // update application records (only those still relevant)
     const commands = [];
-    task.finalScores.forEach(scoreData => {
+    task.finalScores.filter(scoreData => applicationIdMap[scoreData.id]).forEach(scoreData => {
       let newStatus;
       if (scoreData[scoreType] > task.passMark) {
         newStatus = passStatus;


### PR DESCRIPTION
Changes our code to import scores from the new QT platform so we no longer expect scores for all applications.

Also only updates status of application records that are still relevant (i.e. haven't been moved to draft or withdrawn)

Closes #855 