### PR TITLE
jac-uk/admin#1981 Targeted outreach report should use NINO

### DIFF
--- a/functions/actions/candidates/search.js
+++ b/functions/actions/candidates/search.js
@@ -113,6 +113,7 @@ module.exports = (firebase, db) => {
           email: candidateData[candidates[i].id].email.toLowerCase(),
           computed: {
             search: search,
+            nino: candidateData[candidates[i].id].nationalInsuranceNumber,
             exercisesMap: candidateData[candidates[i].id].exercisesMap,
             applicationsMap: candidateData[candidates[i].id].applicationsMap,
             referenceNumbers: candidateData[candidates[i].id].referenceNumbers,

--- a/functions/actions/exercises/targetedOutreachReport.js
+++ b/functions/actions/exercises/targetedOutreachReport.js
@@ -29,7 +29,7 @@ module.exports = (firebase, db) => {
       if (singleNationalInsuranceNumber) {
         
         const candidates = await getDocuments(db.collection('candidates')
-          .where('computed.search', 'array-contains', singleNationalInsuranceNumber)
+          .where('computed.nino', '==', singleNationalInsuranceNumber)
         );
 
         if (candidates.length > 0) {


### PR DESCRIPTION
Amends targeted outreach report to search against a new `computed.nino` field in the `candidate` document.
Previously it was searching against `computed.search` and so was matching on name, reference number and email

Closes jac-uk/admin#1981