### PR TITLE
Release workflow: Move storage rules to last task

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -28,9 +28,6 @@ jobs:
       - run: npm run production:deploy:rules
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
-      - run: npm run production:deploy:storage-rules
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
       - run: npm run production:deploy:realtime-rules
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
@@ -38,5 +35,8 @@ jobs:
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
       - run: npm run production:deploy:functions
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
+      - run: npm run production:deploy:storage-rules
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}


### PR DESCRIPTION
There is currently a firebase issue preventing storage rules from deploying:
https://github.com/firebase/firebase-tools/issues/5955

Here I have moved our command to deploy storage rules to last in the list of tasks so that if it fails it doesn't prevent the other tasks from being run