### PR TITLE
Bugfix: [jac-uk/admin#2086] Vacancy model...

### DIFF
--- a/functions/shared/factories.js
+++ b/functions/shared/factories.js
@@ -609,8 +609,9 @@ module.exports = (CONSTANTS) => {
       yesSalaryDetails: null,
     };
     const vacancy = { ...vacancyModel };
+    const dataKeys = Object.keys(data);
     for (var key in vacancyModel) {
-      if (data[key]) {
+      if (dataKeys.includes(key)) {
         vacancy[key] = data[key];
       }
     }


### PR DESCRIPTION
Closes jac-uk/admin#2086

The fix here ensures exercise boolean fields are correctly copied across to the corresponding vacancy. 

**Before** 
a `false` value in Exercise becomes a `null` value in Vacancy

**After** 
a `false` value in Exercise becomes a `false` value in Vacancy

