### PR TITLE
[jac-uk/admin#2058] Include status for noScenarioTestSubmitted

### DIFF
--- a/functions/actions/tasks/taskHelpers.js
+++ b/functions/actions/tasks/taskHelpers.js
@@ -132,6 +132,8 @@ module.exports = (config) => {
     case TASK_TYPE.SITUATIONAL_JUDGEMENT:
     case TASK_TYPE.QUALIFYING_TEST:
       return 'noTestSubmitted';
+    case TASK_TYPE.SCENARIO:
+      return 'noScenarioTestSubmitted';
     default:
       return null;
     }


### PR DESCRIPTION
Simple change to introduce a new status for `noScenarioTestSubmitted`

Closes jac-uk/admin#2058