### PR TITLE
Feature/2089 Generate statutory consultation report

### DIFF
--- a/functions/actions/exercises/generateStatutoryConsultationReport.js
+++ b/functions/actions/exercises/generateStatutoryConsultationReport.js
@@ -25,11 +25,11 @@ module.exports = (firebase, db) => {
 
     // get report with judicial experience
     const judicialData = reportData(db, applications, true);
-    const judicialHeaders = reportHeaders(judicialData.maxQualificationNum, judicialData.maxExperienceNum);
+    const judicialHeaders = reportHeaders(judicialData.maxQualificationNum, judicialData.maxExperienceNum, true);
 
     // get report with non-judicial experience
     const nonJudicialData = reportData(db, applications, false);
-    const nonJudicialHeaders = reportHeaders(nonJudicialData.maxQualificationNum, nonJudicialData.maxExperienceNum);
+    const nonJudicialHeaders = reportHeaders(nonJudicialData.maxQualificationNum, nonJudicialData.maxExperienceNum, false);
 
     // construct the report document
     const report = {
@@ -56,15 +56,16 @@ module.exports = (firebase, db) => {
  * 
  * @param {number} maxQualificationNum
  * @param {number} maxExperienceNum
+ * @param {boolean} isJudicial
  * @return {array}
  */
-const reportHeaders = (maxQualificationNum, maxExperienceNum) => {
+const reportHeaders = (maxQualificationNum, maxExperienceNum, isJudicial = null) => {
   const headers = [
     { title: 'First name', ref: 'firstName' },
     { title: 'Last name', ref: 'lastName' },
     { title: 'Suffix', ref: 'suffix' },
     ...getQualificationHeaders(maxQualificationNum),
-    ...getExperienceHeaders(maxExperienceNum),
+    ...getExperienceHeaders(maxExperienceNum, isJudicial),
     ...getJudicialExperienceHeaders(),
   ];
 
@@ -98,7 +99,6 @@ const reportData = (db, applications, isJudicial = null) => {
     });
     // sort experiences by start date descending
     filteredExperiences.sort((a, b) => getDate(b.startDate) > getDate(a.startDate));
-
 
     maxQualificationNum = qualifications.length > maxQualificationNum ? qualifications.length : maxQualificationNum;
     maxExperienceNum = filteredExperiences.length > maxExperienceNum ? filteredExperiences.length : maxExperienceNum;
@@ -134,11 +134,12 @@ function getQualificationHeaders(n) {
   return headers;
 }
 
-function getExperienceHeaders(n) {
+function getExperienceHeaders(n, isJudicial = null) {
   const headers = [];
   for (let i = 1; i <= n; i++) {
+    const roleTitle = isJudicial ? `${ordinal(i)} Judicial Role` : `${ordinal(i)} Organisational Business`;
     headers.push(
-      { title: `${ordinal(i)} Organisation or business`, ref: `orgBusinessName${i}` },
+      { title: roleTitle, ref: `orgBusinessName${i}` },
       { title: 'Job title', ref: `jobTitle${i}` },
       { title: 'Dates', ref: `experienceDates${i}` },
       { title: 'Location', ref: `experienceLocation${i}` },

--- a/functions/shared/helpers.js
+++ b/functions/shared/helpers.js
@@ -238,6 +238,9 @@ function toTimeString(date) {
 function formatDate(value, type) {
   value = convertToDate(value);
   if (value) {
+    const day = value.getDate();
+    const month = value.getMonth() + 1;
+    const year = value.getFullYear();
     const time = value.toLocaleTimeString('en-GB', {
       hour: '2-digit',
       minute:'2-digit',
@@ -251,7 +254,7 @@ function formatDate(value, type) {
         break;
       case 'DD/MM/YYYY':
         // e.g. 30/11/2022 (ref: https://momentjs.com/docs/#/displaying/format/)
-        value = value.toLocaleDateString();
+        value = `${day}/${month}/${year}`; // toLocaleDateString('en-GB') returns 30/11/2022 for some reason
         break;
       case 'date-hour-minute':
         // e.g. Wednesday, 30 November, 2022 at 13:00


### PR DESCRIPTION
Generate statutory consultation reports with judicial and non-judicial experiences.

The differentiator between judicial and non-judicial is where the candidate selects from the tick boxes; if they select `The carrying-out of judicial functions of any court or tribunal` it is judicial, any of the other options are non-judicial.

![image](https://github.com/jac-uk/digital-platform/assets/79906532/64d755ba-5dc9-4e51-a18e-2e0548db4a0c)

Note: this work is related to [admin: Feature/2089 Statutory consultation report](https://github.com/jac-uk/admin/pull/2094).