### PR TITLE
Keep track of release tasks & a plan for running them

### DIFF
--- a/releaseJobs.txt
+++ b/releaseJobs.txt
@@ -1,0 +1,15 @@
+##### This is a stand-alone file that may or may not be useful as a starter-for-ten for managing data migrations (and other jobs) to be run following as part of a release
+##### I have used YAML (I think!) so that this could be consumed by a job-runner script. If the job runner detects that the release includes the mentioned PR (or issue) then it will run each of the associated commands
+##### There is likely an off-the-shelf solution but if not then this could provide a quick & simple way forward that does what we need. This file also provides a history of migration / release commands.
+##### Warning: would need to be careful about who could edit this file as we don't want to run just any old commands
+##### Responsible idiot: Warren Searle
+
+924:
+  npm run production:nodeScript temp/syncExerciseAndVacancyForCompare.js
+920:
+  npm run production:nodeScript temp/syncApplicationsSearchMap.js
+  npm run production:nodeScript temp/syncAssessmentsSearchMap.js
+  npm run production:nodeScript temp/syncCandidatesSearchMap.js
+  npm run production:nodeScript temp/syncExercisesSearchMap.js
+916:
+  npm run production:nodeScript migrateAssessmentMethods


### PR DESCRIPTION
Created this as part of a recent release that involved running a few migration scripts.

Adding it to our code base for future reference and in case there's need to better support running migration scripts as part of releases.

There are probably existing solutions we could use but if not this proposes a simple way we could implement our own:

write a workflow job which:
 - parses the issues/PRs in the release
 - parses the `releaseJobs` file and if it finds a matching Issue number then
 - runs the corresponding commands