### PR TITLE
Empty Qualifications Break Exercise Data Export

### DIFF
--- a/functions/actions/exercises/exportExerciseData.js
+++ b/functions/actions/exercises/exportExerciseData.js
@@ -180,7 +180,7 @@ module.exports = (config, firebase, db) => {
         ].join(', ');
       }).join('\n');
     }
-    return data;
+    return '';
   }
   function formatFeePaidOrSalariedJudge(application) {
     if (!application) { return application; }


### PR DESCRIPTION
Qualifications formatter function should return a string but was returning an empty array when no qualifications. Fixed by returning an empty string instead.
(This has already been deployed to Prod as a hotfix)