### PR TITLE
#940 Bugfix: handle missing data for previous address

### DIFF
--- a/functions/actions/exercises/generateHandoverReport.js
+++ b/functions/actions/exercises/generateHandoverReport.js
@@ -215,11 +215,13 @@ const formatPersonalDetails = (personalDetails) => {
 
   let formattedPreviousAddresses;
   if (personalDetails.address && !personalDetails.address.currentMoreThan5Years) {
-    formattedPreviousAddresses = personalDetails.address.previous.map((address) => {
-      const dates = `${helpers.formatDate(address.startDate)} - ${helpers.formatDate(address.endDate)}`;
-      const formattedAddress = formatAddress(address);
-      return `${dates} ${formattedAddress}`;
-    }).join('\n\n');
+    if (personalDetails.address.previous) {
+      formattedPreviousAddresses = personalDetails.address.previous.map((address) => {
+        const dates = `${helpers.formatDate(address.startDate)} - ${helpers.formatDate(address.endDate)}`;
+        const formattedAddress = formatAddress(address);
+        return `${dates} ${formattedAddress}`;
+      }).join('\n\n');  
+    }
   }
 
   let candidate = {

--- a/nodeScripts/generateHandoverReport.js
+++ b/nodeScripts/generateHandoverReport.js
@@ -4,13 +4,13 @@ const { firebase, app, db } = require('./shared/admin.js');
 const { generateHandoverReport } = require('../functions/actions/exercises/generateHandoverReport')(firebase, db);
 
 const main = async () => {
-  return generateHandoverReport('DqKdMSMOmxArSWYsDyhZ');
+  return generateHandoverReport('ofWyUMtAGBGj6AVck2tH');
 };
 
 main()
   .then((result) => {
     result;
-    console.log('result');
+    console.log('result', result);
     app.delete();
     return process.exit();
   })


### PR DESCRIPTION
In Admin the Exercise Handover Report was not being generated for exercise JAC00120.

Upon further investigation it appears one of the applications is missing previous address data when we are expecting it to be there (as the candidate has been at their current address less than 5 years).

Our function `generateHandoverReport` breaks if there's an application with missing previous address data, when it's expecting it to be there.

Here we are better handling missing previous address data

Closes #940