### PR TITLE
Outreach report fixes

### DIFF
--- a/nodeScripts/addProcessingToApplications.js
+++ b/nodeScripts/addProcessingToApplications.js
@@ -9,8 +9,10 @@ const { firebase, app, db } = require('./shared/admin.js');
 const { getDocument, getDocuments, applyUpdates, objectHasNestedProperty } = require('../functions/shared/helpers.js');
 
 async function checkAllApplications() {
-  const applications = await getDocuments(db.collection('applications'));
-  const arr = [];
+  const applications = await getDocuments(db.collection('applications')
+    .where('status', 'in', ['applied', 'withdrawn'])
+    .select('_processing', 'referenceNumber')
+  );
   const commands = [];
   for (let i = 0, len = applications.length; i < len; ++i) {
     const application = applications[i];
@@ -18,7 +20,6 @@ async function checkAllApplications() {
     const hasStageAndStatus = objectHasNestedProperty(application, '_processing.stage') && objectHasNestedProperty(application, '_processing.status');
 
     if (!hasStageAndStatus) {
-      arr.push(application.referenceNumber);
 
       const applicationRecord = await getDocument(db.doc(`applicationRecords/${application.id}`));
 

--- a/nodeScripts/addProcessingToApplications.js
+++ b/nodeScripts/addProcessingToApplications.js
@@ -1,0 +1,68 @@
+'use strict';
+
+/**
+ * Add _processing to applications
+ * This new field holds the 'stage' and 'status' fields from the associated applicationRecord
+ */
+
+const { firebase, app, db } = require('./shared/admin.js');
+const { getDocument, getDocuments, applyUpdates, objectHasNestedProperty } = require('../functions/shared/helpers.js');
+
+async function checkAllApplications() {
+  const applications = await getDocuments(db.collection('applications'));
+  const arr = [];
+  const commands = [];
+  for (let i = 0, len = applications.length; i < len; ++i) {
+    const application = applications[i];
+
+    const hasStageAndStatus = objectHasNestedProperty(application, '_processing.stage') && objectHasNestedProperty(application, '_processing.status');
+
+    if (!hasStageAndStatus) {
+      arr.push(application.referenceNumber);
+
+      const applicationRecord = await getDocument(db.doc(`applicationRecords/${application.id}`));
+
+      if (applicationRecord) {
+        const status = applicationRecord.status ? applicationRecord.status : '';
+        const stage = applicationRecord.stage ? applicationRecord.stage : '';
+  
+        commands.push({
+          command: 'update',
+          ref: application.ref,
+          data: {
+            _processing: {
+              stage: stage,
+              status: status,
+            },
+            lastUpdated: firebase.firestore.FieldValue.serverTimestamp(),
+          },
+        });
+      }
+      else {
+        //console.log(`No applicationRecord for: ${application.referenceNumber}`);
+      }
+    }
+  }
+      
+  console.log('Applications updated:');
+  console.log(commands.length);
+
+  // write to db
+  const result = await applyUpdates(db, commands);
+  return result ? applications.length : false;
+}
+
+const main = async () => {
+  return checkAllApplications();
+};
+
+main()
+  .then((result) => {
+    console.log(result);
+    app.delete();
+    return process.exit();
+  })
+  .catch((error) => {
+    console.error('error', error);
+    process.exit();
+  });


### PR DESCRIPTION
Reduce the footprint of the outreach report by selecting fields in the query, no longer fetching the application records and doing a single loop to build the application arrays.

Add the original keys back into the PAJE stats.
Add a nodeScript to add the _processing field to the application for those that are missing it. This pulls the stage and status into the application record so we dont need to query the application records when building the report anymore.

Closes jac-uk/admin#2097