### PR TITLE
increase getApplicationData limit

### DIFF
--- a/functions/callableFunctions/getApplicationData.js
+++ b/functions/callableFunctions/getApplicationData.js
@@ -7,7 +7,11 @@ const getApplicationData = require('../actions/exercises/getApplicationData')(co
 const { checkFunctionEnabled } = require('../shared/serviceSettings.js')(db);
 const { PERMISSIONS, hasPermissions } = require('../shared/permissions');
 
-module.exports = functions.region('europe-west2').https.onCall(async (data, context) => {
+const runtimeOptions = {
+  memory: '512MB',
+};
+
+module.exports = functions.runWith(runtimeOptions).region('europe-west2').https.onCall(async (data, context) => {
   await checkFunctionEnabled();
   if (!context.auth) {
     throw new functions.https.HttpsError('failed-precondition', 'The function must be called while authenticated.');


### PR DESCRIPTION
Custom report was hitting the memory limit (256) for some exercises, increasing the memory limit for this function should allow the custom report to run again.