### PR TITLE
Feature/Apply#1090 Update Firestore security rules

### DIFF
--- a/database/firestore.rules
+++ b/database/firestore.rules
@@ -208,7 +208,7 @@ service cloud.firestore {
           ||
           (  // pre selection day questionnaire information is requested
           resource.data.status in ["draft", "applied"] && request.resource.data.status in ["draft", "applied"] &&
-          get(/databases/$(database)/documents/applicationRecords/$(applicationId)).data.preSelectionDayQuestionnaire.status in ["created", "requested"]
+          request.resource.data.preSelectionDayQuestionnaire.status in ["requested", "completed"]
           )
         );
 

--- a/database/firestore.rules
+++ b/database/firestore.rules
@@ -43,6 +43,14 @@ service cloud.firestore {
     //  && request.resource.data.keys().hasOnly(all);
   }
 
+  function canUpdateApplicationViaCandidateForm(formId) {
+    return resource.data.status == request.resource.data.status &&
+      resource.data.status in ["draft", "applied"] &&
+      formId in resource.data &&
+      resource.data[formId].status in ["created", "requested"] &&
+      request.resource.data[formId].status in ["created", "requested"];
+  }
+
   match /databases/{database}/documents {
 
     match /{document=**} {
@@ -206,10 +214,7 @@ service cloud.firestore {
           request.resource.data.characterChecks.status in ["requested", "completed"]
           )
           ||
-          (  // pre selection day questionnaire information is requested
-          resource.data.status in ["draft", "applied"] && request.resource.data.status in ["draft", "applied"] &&
-          request.resource.data.preSelectionDayQuestionnaire.status in ["requested", "completed"]
-          )
+          canUpdateApplicationViaCandidateForm('preSelectionDayQuestionnaire')
         );
 
       // allow JAC admins to edit an application @TODO restrict what can be changed and by which role
@@ -312,7 +317,7 @@ service cloud.firestore {
         allow read, update: if userIsAuthenticated() && userIsJAC();
 
         allow read: if userIsAuthenticated() && currentUser() == responseId;
-        allow update: if userIsAuthenticated() && currentUser() == responseId && request.resource.data.applicationId == resource.data.applicationId;
+        allow update: if userIsAuthenticated() && currentUser() == responseId && request.resource.data.applicationId == resource.data.applicationId && resource.data.status != 'completed';
       }
     }
 

--- a/database/firestore.rules
+++ b/database/firestore.rules
@@ -205,6 +205,11 @@ service cloud.firestore {
           resource.data.characterChecks.status == "requested" &&
           request.resource.data.characterChecks.status in ["requested", "completed"]
           )
+          ||
+          (  // pre selection day questionnaire information is requested
+          resource.data.status in ["draft", "applied"] && request.resource.data.status in ["draft", "applied"] &&
+          get(/databases/$(database)/documents/applicationRecords/$(applicationId)).data.preSelectionDayQuestionnaire.status in ["created", "requested"]
+          )
         );
 
       // allow JAC admins to edit an application @TODO restrict what can be changed and by which role

--- a/functions/actions/tasks/updateTask.js
+++ b/functions/actions/tasks/updateTask.js
@@ -599,6 +599,12 @@ module.exports = (config, firebase, db) => {
       });
       const appplicationRecordData = {};
       appplicationRecordData[task.type] = { status: newResponse.status };
+      // store status both in application and applicationRecord
+      commands.push({
+        command: 'update',
+        ref: db.collection('applications').doc(application.id),
+        data: appplicationRecordData,
+      });
       commands.push({
         command: 'update',
         ref: db.collection('applicationRecords').doc(application.id),

--- a/nodeScripts/restoreDocument.js
+++ b/nodeScripts/restoreDocument.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const config = require('../../functions/shared/config.js');
-const { auth, firebase, app, db } = require('../../functions/shared/admin.js');
+const { app, db } = require('../../functions/shared/admin.js');
 
 const main = async () => {
   const documentId = 'JypoxJYQCvV5MEU3T5u3';


### PR DESCRIPTION
- Store the task status in the application document.
- Update Firestore security rules to allow users to amend the information of the pre-selection day questionnaire in the application document.