### PR TITLE
admin#2248 Remove code which copies commissioners to vacancy

### DIFF
--- a/database/firestore.rules
+++ b/database/firestore.rules
@@ -122,8 +122,8 @@ service cloud.firestore {
       allow update: if userIsAuthenticated() && userIsJAC() && hasPermission('s3');
     }
 
-    // allow candidates to access candidateData
-    match /settings/candidateData {
+    // allow candidates to access candidateSettings
+    match /settings/candidateSettings {
       allow read: if userIsAuthenticated();
     }
 

--- a/database/firestore.rules
+++ b/database/firestore.rules
@@ -122,6 +122,11 @@ service cloud.firestore {
       allow update: if userIsAuthenticated() && userIsJAC() && hasPermission('s3');
     }
 
+    // allow candidates to access candidateData
+    match /settings/candidateData {
+      allow read: if userIsAuthenticated();
+    }
+
     match /vacancies/{vacancyId} {
       allow read: if true;
       allow write: if false;

--- a/functions/actions/settings/onUpdate.js
+++ b/functions/actions/settings/onUpdate.js
@@ -1,0 +1,18 @@
+module.exports = (config, firebase, db) => {
+
+  return onUpdate;
+
+  /**
+   * Settings/Services event handler for Update
+   * - if commissioners has changed then copy the latest names to `settings/candidateData`
+   */
+  async function onUpdate(dataBefore, dataAfter) {
+    if (dataBefore.commissioners !== dataAfter.commissioners) {
+      const saveData = {};
+      saveData['commissioners'] = dataAfter.commissioners.map(item => ({ name: item.name }));
+      await db.doc('settings/candidateData').set(saveData, { merge: true });
+    }
+    return true;
+  }
+
+};

--- a/functions/actions/settings/onUpdate.js
+++ b/functions/actions/settings/onUpdate.js
@@ -4,13 +4,13 @@ module.exports = (config, firebase, db) => {
 
   /**
    * Settings/Services event handler for Update
-   * - if commissioners has changed then copy the latest names to `settings/candidateData`
+   * - if commissioners has changed then copy the latest names to `settings/candidateSettings`
    */
   async function onUpdate(dataBefore, dataAfter) {
     if (dataBefore.commissioners !== dataAfter.commissioners) {
       const saveData = {};
       saveData['commissioners'] = dataAfter.commissioners.map(item => ({ name: item.name }));
-      await db.doc('settings/candidateData').set(saveData, { merge: true });
+      await db.doc('settings/candidateSettings').set(saveData, { merge: true });
     }
     return true;
   }

--- a/functions/backgroundFunctions/onSettingsUpdate.js
+++ b/functions/backgroundFunctions/onSettingsUpdate.js
@@ -1,0 +1,12 @@
+const functions = require('firebase-functions');
+const config = require('../shared/config');
+const { firebase, db } = require('../shared/admin.js');
+const onSettingsUpdate = require('../actions/settings/onUpdate')(config, firebase, db);
+
+module.exports = functions.region('europe-west2').firestore
+  .document('settings/services')
+  .onUpdate((change) => {
+    const dataBefore = change.before.data();
+    const dataAfter = change.after.data();
+    return onSettingsUpdate(dataBefore, dataAfter);
+  });

--- a/functions/index.js
+++ b/functions/index.js
@@ -22,6 +22,7 @@ exports.onUserUpdate = require('./backgroundFunctions/onUserUpdate');
 exports.onUserDelete = require('./backgroundFunctions/onUserDelete');
 exports.onRoleUpdate = require('./backgroundFunctions/onRoleUpdate');
 exports.onCandidateFormResponseUpdate = require('./backgroundFunctions/onCandidateFormResponseUpdate');
+exports.onSettingsUpdate = require('./backgroundFunctions/onSettingsUpdate');
 
 // Callable
 exports.getApplicationData = require('./callableFunctions/getApplicationData');

--- a/functions/shared/factories.js
+++ b/functions/shared/factories.js
@@ -645,8 +645,8 @@ module.exports = (CONSTANTS) => {
     const dataKeys = Object.keys(data);
     for (var key in vacancyModel) {
       if (dataKeys.includes(key)) {
-        if (key === 'commissioners') {
-          vacancy[key] = data[key].map(item => ({ name: item.name }));
+        if (key === 'commissioners') { // this is redundant code however has been retained so that we do not copy `commissioners` to `vacancy` document
+          vacancy[key] = [];
         } else {
           vacancy[key] = data[key];
         }


### PR DESCRIPTION
Moves the list of commissioner names from vacancy documents to a new candidate-facing document `settings/candidateSettings`. Here we can store other candidate-facing data & settings in the future.

Closes jac-uk/admin#2248