### PR TITLE
Bugfix/issue 196 Generate agency report

### DIFF
--- a/functions/actions/exercises/generateAgencyReport.js
+++ b/functions/actions/exercises/generateAgencyReport.js
@@ -139,7 +139,7 @@ const reportData = (db, exercise, applications) => {
       qualifications: getFormattedQualifications(qualifications),
       qualificationsDates: getFormattedQualificationsDates(qualifications),
       sraQualifications: qualifications.filter(e => e.type === 'solicitor').map(e => { return { type: e.type, location: e.location, membershipNumber: e.membershipNumber }; }),
-      bsbQualifications: qualifications.filter(e => e.type === 'barrister' || (e.type && e.type.includes('advocate'))).map(e => { return { type: e.type, location: e.location || '', membershipNumber: e.membershipNumber || '' }; }),
+      bsbQualifications: qualifications.filter(e => e.type === 'barrister' || (e.type && e.type.includes('advocate'))).map(e => { return { type: e.type || '', location: e.location || '', membershipNumber: e.membershipNumber || '' }; }),
       otherMemberships: getFormattedOtherMemberships(exercise, application),
       jcioOffice: helpers.toYesNo(application.feePaidOrSalariedJudge) || null,
       jcioPosts: application.experience ? application.experience.map(e => e.jobTitle).join(', ') : null,

--- a/functions/actions/exercises/generateAgencyReport.js
+++ b/functions/actions/exercises/generateAgencyReport.js
@@ -139,7 +139,7 @@ const reportData = (db, exercise, applications) => {
       qualifications: getFormattedQualifications(qualifications),
       qualificationsDates: getFormattedQualificationsDates(qualifications),
       sraQualifications: qualifications.filter(e => e.type === 'solicitor').map(e => { return { type: e.type, location: e.location, membershipNumber: e.membershipNumber }; }),
-      bsbQualifications: qualifications.filter(e => e.type === 'barrister' || (e.type && e.type.includes('advocate'))).map(e => { return { type: e.type, location: e.location, membershipNumber: e.membershipNumber }; }),
+      bsbQualifications: qualifications.filter(e => e.type === 'barrister' || (e.type && e.type.includes('advocate'))).map(e => { return { type: e.type, location: e.location || '', membershipNumber: e.membershipNumber || '' }; }),
       otherMemberships: getFormattedOtherMemberships(exercise, application),
       jcioOffice: helpers.toYesNo(application.feePaidOrSalariedJudge) || null,
       jcioPosts: application.experience ? application.experience.map(e => e.jobTitle).join(', ') : null,

--- a/nodeScripts/generateAgencyReport.js
+++ b/nodeScripts/generateAgencyReport.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { firebase, app, db } = require('./shared/admin.js');
+const { generateAgencyReport } = require('../functions/actions/exercises/generateAgencyReport.js')(firebase, db);
+
+const main = async () => {
+  return generateAgencyReport('ofWyUMtAGBGj6AVck2tH');
+};
+
+main()
+  .then((result) => {
+    result;
+    console.log('result', result);
+    app.delete();
+    return process.exit();
+  })
+  .catch((error) => {
+    console.error('error', error);
+    process.exit();
+  });

--- a/nodeScripts/generateAgencyReport.js
+++ b/nodeScripts/generateAgencyReport.js
@@ -9,7 +9,6 @@ const main = async () => {
 
 main()
   .then((result) => {
-    result;
     console.log('result', result);
     app.delete();
     return process.exit();


### PR DESCRIPTION
Closes [User Raised Issue BR_000009 #196](https://github.com/jac-uk/ticketing-system/issues/196)

- Add a node script to generate an agency report.
- Avoid `undefined` value when preparing data for the report.

![image](https://github.com/jac-uk/digital-platform/assets/79906532/60347beb-dde9-4797-8812-8690b2bf1f18)

