### PR TITLE
Include permission to configure exercise

### DIFF
--- a/functions/shared/permissions.js
+++ b/functions/shared/permissions.js
@@ -77,6 +77,10 @@ const PERMISSIONS = {
         label: 'Can send application reminders',
         value: 'e10',
       },
+      canConfigureExercise: {
+        label: 'Can configure exercise',
+        value: 'e11',
+      },
     },
   },
   candidates: {


### PR DESCRIPTION
Adds a new permission to enable users to configure an exercise - as in change processing version number and/or application form version number.

Note: Firestore security rules have not been updated to check for this permission. Currently the permission is solely used in the UI