### PR TITLE
Ticketing System Fix Regex To Match New Bug Report Number

### DIFF
--- a/functions/actions/bugReports.js
+++ b/functions/actions/bugReports.js
@@ -3,6 +3,7 @@ const { getDocuments } = require('../shared/helpers');
 module.exports = (db) => {
   return {
     getBugReportByRef,
+    getBugReportNumberFromIssueTitle,
   };
 
   async function getBugReportByRef(referenceNumber) {
@@ -12,5 +13,18 @@ module.exports = (db) => {
       return null;
     }
     return bugReports[0];
+  }
+
+  /**
+   * Extract the bugReport referenceNUmber from the github issue title
+   * Checks if the string contains the pattern:
+   * BR_<platform>_<2 letter environment>_<number>
+   * @param {*} issueTitle 
+   * @returns array|null
+   */
+  function getBugReportNumberFromIssueTitle(issueTitle) {
+    const regex = /BR_\w+_\w+_(\d+)/;
+    const match = issueTitle.match(regex);
+    return match ? match[0] : match;
   }
 };


### PR DESCRIPTION
Fixed the regex so its picking up the whole ticket number instead of just the digits (as it was previously)