### PR TITLE
Bugfix/admin 2333 Additional Preferences Duplications

### DIFF
--- a/functions/shared/converters/applicationConverter.js
+++ b/functions/shared/converters/applicationConverter.js
@@ -114,27 +114,28 @@ module.exports = () => {
     const additionalWorkingPreferenceData = application.additionalWorkingPreferences;
     const data = [];
     additionalWorkingPreferenceData.forEach((item, index) => {
-      addField(data, lookup(exercise.additionalWorkingPreferences[index].questionType));
       if (exercise.additionalWorkingPreferences[index].questionType === 'single-choice') {
         addField(data, exercise.additionalWorkingPreferences[index].question, item.selection);
-      }
-      if (exercise.additionalWorkingPreferences[index].questionType === 'multiple-choice' && item.selection) {
-        const multipleChoice = [];
-          item.selection.forEach((choice) => {
-            multipleChoice.push(`<br/>${choice}`);
+      } else if (exercise.additionalWorkingPreferences[index].questionType === 'multiple-choice') {
+        if (item.selection) {
+          const multipleChoice = [];
+            item.selection.forEach((choice) => {
+              multipleChoice.push(`<br/>${choice}`);
+            });
+          addField(data, exercise.additionalWorkingPreferences[index].question, `answer: ${multipleChoice}`);
+        } else {
+          addField(data, exercise.additionalWorkingPreferences[index].question, 'answer: <br/> no answer provided');
+        }
+      } else if (exercise.additionalWorkingPreferences[index].questionType === 'ranked-choice') {
+        if (item.selection) {
+          const rankedAnswer = [];
+          item.selection.forEach((choice, index) => {
+            rankedAnswer.push(`<br/>${index + 1}: ${choice}`);
           });
-        addField(data, exercise.additionalWorkingPreferences[index].question, `answer: ${multipleChoice}`);
-      } else {
-        addField(data, exercise.additionalWorkingPreferences[index].question, 'answer: <br/> no answer provided');
-      }
-      if (exercise.additionalWorkingPreferences[index].questionType === 'ranked-choice' && item.selection) {
-        const rankedAnswer = [];
-        item.selection.forEach((choice, index) => {
-          rankedAnswer.push(`<br/>${index + 1}: ${choice}`);
-        });
-        addField(data, exercise.additionalWorkingPreferences[index].question, `answer: ${rankedAnswer}`);
-      } else {
-        addField(data, exercise.additionalWorkingPreferences[index].question, 'answer: <br/> no answer provided');
+          addField(data, exercise.additionalWorkingPreferences[index].question, `answer: ${rankedAnswer}`);
+        } else {
+          addField(data, exercise.additionalWorkingPreferences[index].question, 'answer: <br/> no answer provided');
+        }
       }
     });
     console.log(data);


### PR DESCRIPTION
## What's included?

Ticket: [Address field duplication, pdf and rogue text issues with Panel packs#2333](https://github.com/jac-uk/admin/issues/2333)

- Fix the duplication of the additional preferences.

## How to test
Example panel: https://admin-develop.judicialappointments.digital/exercise/2M7yxJySfXpINFwvhnnW/reports/sift/view/qhJi1dO6wavZcyGFJ190

1. Go to the example panel "Test1".
2. Click "Export to google drive" button to export the data to Google drive.
3. Go to [Google drive](https://drive.google.com/drive/folders/1dOhgREFvqG6gk20-dwRj1y4jHWjCfJrB) and open the folder "00657 Test1".
4. Open the application data and check if the additional preferences show correctly. 

Demo:

https://github.com/jac-uk/digital-platform/assets/79906532/64fa741a-d0a3-4064-bb59-523d17ac6ced
