### PR TITLE
Ongoing wasnt being displayed in working prefs.

### DIFF
--- a/functions/shared/converters/applicationConverter.js
+++ b/functions/shared/converters/applicationConverter.js
@@ -231,10 +231,7 @@ module.exports = () => {
       experienceData.forEach((e, idx) => {
         const dates = [];
         if (e.startDate) dates.push(helpers.formatDate(e.startDate, 'MMM YYYY'));
-        if (e.isOngoing) dates.push('Ongoing');
-        else if (!Object.prototype.hasOwnProperty.call(e, 'endDate')) { // No end date so is 'ongoing'
-          dates.push('Ongoing');
-        }
+        if (e.isOngoing || !Object.prototype.hasOwnProperty.call(e, 'endDate')) dates.push('Ongoing');   // Support new/old applications
         else if (e.endDate) dates.push(helpers.formatDate(e.endDate, 'MMM YYYY'));
 
         addField(data, 'Job title', e.jobTitle, idx !== 0);

--- a/functions/shared/converters/applicationConverter.js
+++ b/functions/shared/converters/applicationConverter.js
@@ -232,6 +232,9 @@ module.exports = () => {
         const dates = [];
         if (e.startDate) dates.push(helpers.formatDate(e.startDate, 'MMM YYYY'));
         if (e.isOngoing) dates.push('Ongoing');
+        else if (!Object.prototype.hasOwnProperty.call(e, 'endDate')) { // No end date so is 'ongoing'
+          dates.push('Ongoing');
+        }
         else if (e.endDate) dates.push(helpers.formatDate(e.endDate, 'MMM YYYY'));
 
         addField(data, 'Job title', e.jobTitle, idx !== 0);


### PR DESCRIPTION
This is a fix for the following bug:

Description: Spotted when exporting info from the platform for 188 exercise under the work experience information, where applicates have specified the dates they have worked including that this work is ongoing, often only the date appears and the word ongoing is missing..
Expectation: I would expect to see all of the information the candidates have submitted including the word ongoing.

See: https://github.com/jac-uk/ticketing-system/issues/231