### PR TITLE
Bugfix/TS 310 Panel Export Timeout

### DIFF
--- a/functions/backgroundFunctions/onPanelUpdate.js
+++ b/functions/backgroundFunctions/onPanelUpdate.js
@@ -4,7 +4,7 @@ const { firebase, db } = require('../shared/admin.js');
 const onPanelUpdate = require('../actions/panels/onUpdate')(config, firebase, db);
 
 const runtimeOptions = {
-  timeoutSeconds: 180,
+  timeoutSeconds: 300,
 };
 
 module.exports = functions.runWith(runtimeOptions).region('europe-west2').firestore

--- a/functions/backgroundFunctions/onPanelUpdate.js
+++ b/functions/backgroundFunctions/onPanelUpdate.js
@@ -3,7 +3,11 @@ const config = require('../shared/config');
 const { firebase, db } = require('../shared/admin.js');
 const onPanelUpdate = require('../actions/panels/onUpdate')(config, firebase, db);
 
-module.exports = functions.region('europe-west2').firestore
+const runtimeOptions = {
+  timeoutSeconds: 180,
+};
+
+module.exports = functions.runWith(runtimeOptions).region('europe-west2').firestore
   .document('panels/{panelId}')
   .onUpdate((change, context) => {
     const dataBefore = change.before.data();


### PR DESCRIPTION
Closes [User Raised Issue BR_ADMIN_PR_000112 #310](https://github.com/jac-uk/ticketing-system/issues/310)

- Increase the timeout of the background function `onPanelUpdate`.

![image](https://github.com/jac-uk/digital-platform/assets/79906532/824996bf-2808-44f1-b8ab-b6dcefa2531a)
