### PR TITLE
Allow multiple draft application reminders

### DIFF
--- a/functions/actions/applications/applications.js
+++ b/functions/actions/applications/applications.js
@@ -178,9 +178,8 @@ module.exports = (config, firebase, db, auth) => {
       .where('exerciseId', '==', exerciseId)
       .where('status', '==', 'draft');
     let applications = await getDocuments(applicationsRef);
-    // send reminder email if it has not been sent before
     applications = applications.filter(application => {
-      if (application.emailLog && application.emailLog.applicationReminder) return false;
+      //if (application.emailLog && application.emailLog.applicationReminder) return false;
 
       return application.personalDetails && application.personalDetails.fullName && application.personalDetails.email;
     });


### PR DESCRIPTION
Ensure admin users can send multiple draft application reminders when viewing draft applications.
To truly test this you need to either check that the reminder has been received or see that the 'emailLog.applicationReminder' field gets updated in the application record.