### PR TITLE
Feature/admin 2419 Reference statuses in Independent Assessments task

### DIFF
--- a/functions/actions/assessments.js
+++ b/functions/actions/assessments.js
@@ -80,7 +80,7 @@ module.exports = (config, firebase, db) => {
   * Creates assessment requests for each assessor of each application
   * @param {*} `params` is an object containing
   *   `exerciseId` (required) ID of exercise
-  *   `stage` (optional) exercise stage to send out to
+  *   `status` (required) exercise status to send out to
   *   `applicationId` (optional) ID of a specific application to initialise
   */
   async function initialiseAssessments(params) {
@@ -101,7 +101,7 @@ module.exports = (config, firebase, db) => {
       // get applications
       let applicationRecordsSnap = await db.collection('applicationRecords')
         .where('exercise.id', '==', params.exerciseId)
-        .where('stage', '==', params.stage)
+        .where('status', '==', params.status)
         .select() // this is interesting. it allows us to retrieve part or none of the document data (in admin sdk)
         .get();
       const applicationRefs = applicationRecordsSnap.docs.map(item => db.collection('applications').doc(item.id));

--- a/functions/actions/assessments.js
+++ b/functions/actions/assessments.js
@@ -80,7 +80,8 @@ module.exports = (config, firebase, db) => {
   * Creates assessment requests for each assessor of each application
   * @param {*} `params` is an object containing
   *   `exerciseId` (required) ID of exercise
-  *   `status` (required) exercise status to send out to
+  *   `stage` (optional) exercise stage to send out to
+  *   `status` (optional) exercise status to send out to
   *   `applicationId` (optional) ID of a specific application to initialise
   */
   async function initialiseAssessments(params) {
@@ -99,11 +100,15 @@ module.exports = (config, firebase, db) => {
         return false;
       }
       // get applications
-      let applicationRecordsSnap = await db.collection('applicationRecords')
-        .where('exercise.id', '==', params.exerciseId)
-        .where('status', '==', params.status)
-        .select() // this is interesting. it allows us to retrieve part or none of the document data (in admin sdk)
-        .get();
+      let ref = db.collection('applicationRecords').where('exercise.id', '==', params.exerciseId);
+      if (params.stage) {
+        ref = ref.where('stage', '==', params.stage);
+      }
+      if (params.status) {
+        ref = ref.where('status', '==', params.status);
+      }
+      ref = ref.select(); // this is interesting. it allows us to retrieve part or none of the document data (in admin sdk)
+      let applicationRecordsSnap = await ref.get();
       const applicationRefs = applicationRecordsSnap.docs.map(item => db.collection('applications').doc(item.id));
       applications = await getAllDocuments(db, applicationRefs); // N.B. we could use a field mask here e.g. { fieldMask: ['status'] }
     }

--- a/functions/actions/exercises/refreshApplicationCounts.js
+++ b/functions/actions/exercises/refreshApplicationCounts.js
@@ -76,6 +76,7 @@ module.exports = (firebase, db) => {
     const counts = {
       _total: applicationRecords.length,
       _lastUpdated: firebase.firestore.FieldValue.serverTimestamp(),
+      status: {},
     };
     applicationRecords.forEach(applicationRecord => {
       if (counts[applicationRecord.stage]) {
@@ -83,6 +84,14 @@ module.exports = (firebase, db) => {
       } else {
         counts[applicationRecord.stage] = 1;
       }
+
+      const status = applicationRecord.status || '';
+      if (counts.status[status]) {
+        counts.status[status]++;
+      } else {
+        counts.status[status] = 1;
+      }
+
       // EMP counts
       if (applicationRecord.flags && applicationRecord.flags.empApplied) {
         const countName = `${applicationRecord.stage}EMP`;

--- a/functions/callableFunctions/initialiseAssessments.js
+++ b/functions/callableFunctions/initialiseAssessments.js
@@ -22,7 +22,8 @@ module.exports = functions.region('europe-west2').https.onCall(async (data, cont
 
   if (!checkArguments({
     exerciseId: { required: true },
-    status: { required: true },
+    stage: { required: false },
+    status: { required: false },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
   }

--- a/functions/callableFunctions/initialiseAssessments.js
+++ b/functions/callableFunctions/initialiseAssessments.js
@@ -22,7 +22,7 @@ module.exports = functions.region('europe-west2').https.onCall(async (data, cont
 
   if (!checkArguments({
     exerciseId: { required: true },
-    stage: { required: true },
+    status: { required: true },
   }, data)) {
     throw new functions.https.HttpsError('invalid-argument', 'Please provide valid arguments');
   }


### PR DESCRIPTION
- Update the callable function `initialiseAssessments` to initialise assessments with application status.
- Update the callable function `refreshApplicationCounts` to save/refresh application status counts in `_applicationRecords.status[STATUS]` in the exercise document.