### PR TITLE
Feature/admin 2419 Reference statuses in Independent Assessments task

### DIFF
--- a/functions/actions/assessments.js
+++ b/functions/actions/assessments.js
@@ -105,7 +105,11 @@ module.exports = (config, firebase, db) => {
         ref = ref.where('stage', '==', params.stage);
       }
       if (params.status) {
-        ref = ref.where('status', '==', params.status);
+        if (params.status === 'blank') {
+          ref = ref.where('status', '==', '');
+        } else {
+          ref = ref.where('status', '==', params.status);
+        }
       }
       ref = ref.select(); // this is interesting. it allows us to retrieve part or none of the document data (in admin sdk)
       let applicationRecordsSnap = await ref.get();

--- a/functions/actions/exercises/refreshApplicationCounts.js
+++ b/functions/actions/exercises/refreshApplicationCounts.js
@@ -85,7 +85,7 @@ module.exports = (firebase, db) => {
         counts[applicationRecord.stage] = 1;
       }
 
-      const status = applicationRecord.status || '';
+      const status = applicationRecord.status || 'blank';
       if (counts.status[status]) {
         counts.status[status]++;
       } else {


### PR DESCRIPTION
- Update the callable function `initialiseAssessments` to allow initialising assessments with a `blank` status.