### PR TITLE
Bugfix/1091 Fix Github Warnings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/firestore-indexes.yml
+++ b/.github/workflows/firestore-indexes.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       ## Install
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.DEPLOY_TOKEN }}
       - uses: actions/setup-node@master
@@ -40,7 +40,7 @@ jobs:
       - name: Get package version (for pushes)
         if: github.event_name == 'push' && success()
         id: package_version
-        run: echo "::set-output name=current_version::$(node -p "require('./package.json').version")"
+        run: echo "name=current_version::$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Bump package version (for pushes)
         if: github.event_name == 'push' && success() &&
           steps.package_version.outputs.current_version != steps.release_drafter.outputs.tag_name

--- a/.github/workflows/firestore-rules.yml
+++ b/.github/workflows/firestore-rules.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       ## Install and test
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.DEPLOY_TOKEN }}
       - uses: actions/setup-node@master
@@ -42,7 +42,7 @@ jobs:
       - name: Get package version (for pushes)
         if: github.event_name == 'push' && success()
         id: package_version
-        run: echo "::set-output name=current_version::$(node -p "require('./package.json').version")"
+        run: echo "name=current_version::$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Bump package version (for pushes)
         if: github.event_name == 'push' && success() &&
           steps.package_version.outputs.current_version != steps.release_drafter.outputs.tag_name

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       ## Install and test
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.DEPLOY_TOKEN }}
       - uses: actions/setup-node@master
@@ -49,7 +49,7 @@ jobs:
       - name: Get package version (for pushes)
         if: github.event_name == 'push' && success()
         id: package_version
-        run: echo "::set-output name=current_version::$(node -p "require('./package.json').version")"
+        run: echo "name=current_version::$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Bump package version (for pushes)
         if: github.event_name == 'push' && success() &&
           steps.package_version.outputs.current_version != steps.release_drafter.outputs.tag_name

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -8,9 +8,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       ## Install and test
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.DEPLOY_TOKEN }}
       - uses: actions/setup-node@master

--- a/.github/workflows/storage-rules.yml
+++ b/.github/workflows/storage-rules.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       ## Install
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.DEPLOY_TOKEN }}
       - uses: actions/setup-node@master
@@ -40,7 +40,7 @@ jobs:
       - name: Get package version (for pushes)
         if: github.event_name == 'push' && success()
         id: package_version
-        run: echo "::set-output name=current_version::$(node -p "require('./package.json').version")"
+        run: echo "name=current_version::$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Bump package version (for pushes)
         if: github.event_name == 'push' && success() &&
           steps.package_version.outputs.current_version != steps.release_drafter.outputs.tag_name


### PR DESCRIPTION
Fix Github action warnings:
- Upgrade `actions/checkout` and `actions/cache` to `v4`.
- Upgrade `github/codeql-action` to `v3`.
- Update deprecating `::set-output` command ([GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)).

![warning1](https://github.com/jac-uk/digital-platform/assets/79906532/68459179-8f95-41dd-809a-f5664c86f633)
![warning2](https://github.com/jac-uk/digital-platform/assets/79906532/023c693b-fdfa-49af-9216-77de91ecf272)
