### PR TITLE
Bugfix/1091 Github Actions

### DIFF
--- a/.github/workflows/firestore-indexes.yml
+++ b/.github/workflows/firestore-indexes.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Get package version (for pushes)
         if: github.event_name == 'push' && success()
         id: package_version
-        run: echo "name=current_version::$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+        run: echo "current_version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Bump package version (for pushes)
         if: github.event_name == 'push' && success() &&
           steps.package_version.outputs.current_version != steps.release_drafter.outputs.tag_name

--- a/.github/workflows/firestore-rules.yml
+++ b/.github/workflows/firestore-rules.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Get package version (for pushes)
         if: github.event_name == 'push' && success()
         id: package_version
-        run: echo "name=current_version::$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+        run: echo "current_version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Bump package version (for pushes)
         if: github.event_name == 'push' && success() &&
           steps.package_version.outputs.current_version != steps.release_drafter.outputs.tag_name

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Get package version (for pushes)
         if: github.event_name == 'push' && success()
         id: package_version
-        run: echo "name=current_version::$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+        run: echo "current_version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Bump package version (for pushes)
         if: github.event_name == 'push' && success() &&
           steps.package_version.outputs.current_version != steps.release_drafter.outputs.tag_name

--- a/.github/workflows/storage-rules.yml
+++ b/.github/workflows/storage-rules.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Get package version (for pushes)
         if: github.event_name == 'push' && success()
         id: package_version
-        run: echo "name=current_version::$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+        run: echo "current_version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Bump package version (for pushes)
         if: github.event_name == 'push' && success() &&
           steps.package_version.outputs.current_version != steps.release_drafter.outputs.tag_name


### PR DESCRIPTION
Fix Github action warnings:
- Update deprecating `::set-output` command ([GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)).