### PR TITLE
Include `_processingVersion` in `vacancy` model

### DIFF
--- a/functions/shared/factories.js
+++ b/functions/shared/factories.js
@@ -556,6 +556,7 @@ module.exports = (CONSTANTS) => {
     const vacancyModel = {
       _applicationContent: null,
       _applicationVersion: null,
+      _processingVersion: null,
       aboutTheRole: null,
       aboutTheRoleWelsh: null,
       additionalWorkingPreferences: null,


### PR DESCRIPTION
Includes `_processingVersion` in our `vacancy` model.

In particular this helps our `exerciseHelper` library to use the correct stages and statuses as they changed in processingVersion 2+.

Closes jac-uk/admin#2496