### PR TITLE
can publish listing exercise without approval

### DIFF
--- a/functions/actions/exercises/onUpdate.js
+++ b/functions/actions/exercises/onUpdate.js
@@ -17,9 +17,10 @@ module.exports = (config, firebase, db, auth) => {
     const isDraftOrReady = dataAfter.state === 'draft' || dataAfter.state === 'ready';
     const isPreviouslyApproved = objectHasNestedProperty(dataAfter, '_approval.initialApprovalDate');
     const isUnlocked = isDraftOrReady && isPreviouslyApproved;
+    const canPostWithoutApproval = !['listing'].includes(dataAfter.advertType); 
 
     if (dataAfter.published === true) {
-      if (!isUnlocked) {
+      if (!isUnlocked || canPostWithoutApproval) {
         // Update the vacancy if the exercise is published but not in the unlocked state (as the changes will need approval first)
         await updateVacancy(exerciseId, dataAfter);
       }


### PR DESCRIPTION
- What includes
  - Closes https://github.com/jac-uk/ticketing-system/issues/365
  - Allow listing exercise can be published without approval.

- How to test
  - Go to listing exercise without approval: https://admin-develop.judicialappointments.digital/exercise/8BlswaF8CCogRWPSPQln/details/summary/?referrer=exercise-show-overview
  - Publish the exercise, and check if it appears on Apply site