### PR TITLE
add indexes for querying favorite exercises

### DIFF
--- a/database/firestore.indexes.json
+++ b/database/firestore.indexes.json
@@ -2713,6 +2713,20 @@
           "arrayConfig": "CONTAINS"
         },
         {
+          "fieldPath": "createdAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "exercises",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "favouriteOf",
+          "arrayConfig": "CONTAINS"
+        },
+        {
           "fieldPath": "name",
           "order": "ASCENDING"
         }


### PR DESCRIPTION
Closes https://github.com/jac-uk/ticketing-system/issues/370

** Issue
The my favourite exercises page in Admin site can not load data.

** Fix
Add index for querying favourite exercises.