### PR TITLE
Improve legibility in panel pack layout

### DIFF
--- a/functions/shared/converters/applicationConverter.js
+++ b/functions/shared/converters/applicationConverter.js
@@ -262,10 +262,10 @@ module.exports = () => {
   function getAdditionalSelectionCriteria(application, exercise) {
     const additionalSelectionCriteria = application.selectionCriteriaAnswers;
     const data = [];
-    const answer = sC.answerDetails || 'Does not meet this requirement';
     additionalSelectionCriteria.forEach((sC, index) => {
+      const answer = sC.answerDetails || 'Does not meet this requirement';
       // The last argument below tells addField that the heading and data should go in separate rows
-      addField(data, exercise.selectionCriteria[index].title, answer, true);
+      addField(data, exercise.selectionCriteria[index].title, answer, false, true);
     });
     return data;
   }

--- a/functions/shared/converters/applicationConverter.js
+++ b/functions/shared/converters/applicationConverter.js
@@ -125,7 +125,8 @@ module.exports = () => {
     const data = [];
     if (!selfAssessmentData || !exercise.selfAssessmentWordLimits) return data;
     selfAssessmentData.forEach((q, i) => {
-      addField(data, exercise.selfAssessmentWordLimits[i].question, q);
+      // The last argument below tells addField that the heading and data should go in separate rows
+      addField(data, exercise.selfAssessmentWordLimits[i].question, q, false, true);
     });
     return data;
   }
@@ -261,8 +262,10 @@ module.exports = () => {
   function getAdditionalSelectionCriteria(application, exercise) {
     const additionalSelectionCriteria = application.selectionCriteriaAnswers;
     const data = [];
+    const answer = sC.answerDetails || 'Does not meet this requirement';
     additionalSelectionCriteria.forEach((sC, index) => {
-      addField(data, exercise.selectionCriteria[index].title, sC.answerDetails || 'Does not meet this requirement');
+      // The last argument below tells addField that the heading and data should go in separate rows
+      addField(data, exercise.selectionCriteria[index].title, answer, true);
     });
     return data;
   }

--- a/functions/shared/converters/helpers.js
+++ b/functions/shared/converters/helpers.js
@@ -1,14 +1,23 @@
 const lookup = require('./lookup');
 const { Timestamp } = require('firebase-admin/firestore');
 
-const addField = (array, label, value, lineBreak = false) => {
+/**
+ * 
+ * @param {*} array 
+ * @param {*} label 
+ * @param {*} value 
+ * @param {*} lineBreak 
+ * @param {*} dataOnSeparateRow Display heading and value in separate rows
+ * @returns 
+ */
+const addField = (array, label, value, lineBreak = false, dataOnSeparateRow = false) => {
   if (value === undefined || value === null || value === '') {
     return;
   }
   if (typeof (value) === 'boolean') {
     value = toYesNo(value);
   }
-  array.push({ value: value, label: label, lineBreak: lineBreak });
+  array.push({ value: value, label: label, lineBreak: lineBreak, dataOnSeparateRow: dataOnSeparateRow });
 };
 
 const toYesNo = (value) => {

--- a/functions/shared/htmlWriter.js
+++ b/functions/shared/htmlWriter.js
@@ -112,9 +112,13 @@ class htmlWriter {
     data.forEach(each => {
       const heading = each.label;
       let value = each.value;
-
       let html = each.lineBreak ? rowStartSectionStart : rowStart;
-      html += headingStart + heading + headingEnd + dataStart + value + dataEnd + rowEnd;
+      if (each.dataOnSeparateRow) { // Put heading and value in separate rows
+        html += headingStart + heading + headingEnd  + rowEnd + rowStart + dataStart + value + dataEnd + rowEnd;
+      }
+      else { // Put heading and value in same row
+        html += headingStart + heading + headingEnd + dataStart + value + dataEnd + rowEnd;
+      }
       rowHtml.push(html);
     });
     rowHtml.unshift(tableStart);

--- a/test/shared/applicationConverter.spec.js
+++ b/test/shared/applicationConverter.spec.js
@@ -680,16 +680,19 @@ describe('applicationConverter', () => {
             label: 'Sc1',
             'lineBreak': false,
             'value': 'title1',
+            'dataOnSeparateRow': true,
           },
           {
             label: 'sc2',
             'lineBreak': false,
             'value': 'title2',
+            'dataOnSeparateRow': true,
           },
           {
             label: 'SC3',
             'lineBreak': false,
             'value': 'title3',
+            'dataOnSeparateRow': true,
           },
         ]);
     });
@@ -726,16 +729,19 @@ describe('applicationConverter', () => {
           label: 'Organisation or business',
           lineBreak: false,
           value: 'name',
+          dataOnSeparateRow: false,
         },
         {
           label: 'Job title',
           lineBreak: false,
           value: 'title',
+          dataOnSeparateRow: false,
         },
         {
           label: 'Date qualified',
           lineBreak: false,
           value: '01/08/2022 - 02/08/2022',
+          dataOnSeparateRow: false,
         },
       ]);
     });


### PR DESCRIPTION
Added a flag to tell the addTable function that the header and value should go in separate rows instead of two columns in the same row.
Updated function calls to getAdditionalSelectionCriteria and getSelfAssessment to use this flag.

Closes #1167 