### PR TITLE
Bugfix: Create selection day was using wrong constant

### DIFF
--- a/functions/shared/Timeline/exerciseTimeline.TMP.js
+++ b/functions/shared/Timeline/exerciseTimeline.TMP.js
@@ -36,7 +36,7 @@ export default (config) => {
       date: selectionDay.selectionDayStart,
       endDate: selectionDay.selectionDayEnd,
       dateString: null,
-      taskType: TASK_TYPE.SELECTION,
+      taskType: TASK_TYPE.SELECTION_DAY,
     };
 
     const selectionDayStart = getDateString(selectionDay.selectionDayStart);


### PR DESCRIPTION
Small fix to `createTask` function so it's using the correct constant for `SELECTION_DAY`