### PR TITLE
Remove assessment dueDate from firestore security rule

### DIFF
--- a/database/firestore.rules
+++ b/database/firestore.rules
@@ -267,8 +267,7 @@ service cloud.firestore {
         (!('id' in request.resource.data.assessor) || request.resource.data.assessor.id == currentUser()) &&
         resource.data.assessor.email == request.resource.data.assessor.email &&
         resource.data.status == 'pending' &&
-        (request.resource.data.status == 'completed' || request.resource.data.status == 'declined') &&
-        request.time <= resource.data.dueDate;
+        (request.resource.data.status == 'completed' || request.resource.data.status == 'declined');
         // TODO allow uploads after the due date but before the hard limit resource.data.dueDate >= request.time;
     }
 

--- a/test/rules/7.assessments.spec.js
+++ b/test/rules/7.assessments.spec.js
@@ -133,12 +133,12 @@ describe('Assessments', () => {
       );
       await assertFails(db.collection('assessments').doc('assessment1').update({ status: 'completed', 'assessor.email': 'user2@user2.user2' }));
     });
-    it('prevent authenticated user from updating assessment after the due date', async () => {
+    it('allow authenticated user to update assessment after the due date', async () => {
       const db = await setup(
         { uid: 'user1', email: 'user1@user1.user1', email_verified: true },
         { 'assessments/assessment1': { assessor: { email: 'user1@user1.user1' }, status: 'pending', dueDate: getTimeStamp(yesterday) } }
       );
-      await assertFails(db.collection('assessments').doc('assessment1').update({ status: 'completed' }));
+      await assertSucceeds(db.collection('assessments').doc('assessment1').update({ status: 'completed' }));
     });
     it('prevent JAC admin without permission from updating assessment data', async () => {
       const db = await setup(


### PR DESCRIPTION
We want to allow assessors to upload docs after the hard due date