### PR TITLE
Escape title and body of request to prevent errors when making graphQL call

### DIFF
--- a/functions/shared/zenhub.js
+++ b/functions/shared/zenhub.js
@@ -34,10 +34,15 @@ export default (config) => {
    * @returns 
    */
   async function createZenhubIssue(referenceNumber, body) {
+
+    console.log('Making API call to zenhub...');
+
     const platformIssuesRepositoryId = config.ZENHUB_ISSUES_WORKSPACE_ID;
     if (baseApiUrl && apiKey) {
       try {
         const title = `User Raised Issue ${referenceNumber}`;
+        const escapedTitle = JSON.stringify(title);
+        const escapedBody = JSON.stringify(body);
         const result = await axios({
           url: baseApiUrl,
           method: 'post',
@@ -47,8 +52,8 @@ export default (config) => {
             query: `
               mutation createIssue {
                 createIssue(input: {
-                    title: "${title}",
-                    body: "${body}",
+                    title: ${escapedTitle},
+                    body: ${escapedBody},
                     repositoryId: "${platformIssuesRepositoryId}"
                 }) {
                     issue {
@@ -60,7 +65,6 @@ export default (config) => {
             `,
           },
         });
-
         if (objectHasNestedProperty(result, 'data.errors')) {
           const errorsStr = result.data.errors.map(e => e.message).join('\n');
           throw new Error(errorsStr);
@@ -92,6 +96,8 @@ export default (config) => {
     if (baseApiUrl && apiKey) {
       try {
         const title = `User Raised Issue ${referenceNumber}`;
+        const escapedTitle = JSON.stringify(title);
+        const escapedBody = JSON.stringify(body);
         const result = await axios({
           url: baseApiUrl,
           method: 'post',
@@ -101,8 +107,8 @@ export default (config) => {
             query: `
               mutation createIssue {
                 createIssue(input: {
-                    title: "${title}",
-                    body: "${body}",
+                    title: ${escapedTitle},
+                    body: ${escapedBody},
                     repositoryId: "${platformIssuesRepositoryId}"
                     labels: ["${label}"],
                 }) {

--- a/functions/shared/zenhub.js
+++ b/functions/shared/zenhub.js
@@ -34,9 +34,6 @@ export default (config) => {
    * @returns 
    */
   async function createZenhubIssue(referenceNumber, body) {
-
-    console.log('Making API call to zenhub...');
-
     const platformIssuesRepositoryId = config.ZENHUB_ISSUES_WORKSPACE_ID;
     if (baseApiUrl && apiKey) {
       try {

--- a/nodeScripts/testZenhub.js
+++ b/nodeScripts/testZenhub.js
@@ -6,21 +6,37 @@
  * Run with: > npm run local:nodeScript testZenHub.js
  */
 
-import config from './shared/config.js';
+import { app } from './shared/admin.js';
+//import config from './shared/config.js';
+import config from '../functions/shared/config.js';
 import initZenhub from '../functions/shared/zenhub.js';
 
 const zenhub = initZenhub(config);
 
 const main = async () => {
-  return zenhub.createZenhubIssue('BR0001', 'Test new issue body');
+
+
+  try {
+    const newIssueID = await zenhub.createZenhubIssue('TESTER2', '"Test" new issue body');
+    console.log(`newIssueID: ${newIssueID}`);
+    return true;
+  }
+  catch (e) {
+    console.log('ERROR:');
+    console.log(e);
+    return false;
+  }
+
+
 };
 
 main()
-  .then((newIssueID) => {
-    console.log(`New issue ID: ${newIssueID}`);
+  .then((result) => {
+    console.log(result);
+    app.delete();
     return process.exit();
   })
   .catch((error) => {
-    console.error(error);
+    console.error('error', error);
     process.exit();
   });


### PR DESCRIPTION
Escape title and body so that speech marks done cause issues when sending the graphQL request.
An admin user tried to raise a ticket but had entered speech marks in the body of the form. This fix should escape these so that the request doesnt fail.