### PR TITLE
1261 Raise An Issue Not Always Sending Slack Alerts

### DIFF
--- a/database/firestore.indexes.json
+++ b/database/firestore.indexes.json
@@ -2097,6 +2097,20 @@
       ]
     },
     {
+      "collectionGroup": "bugReports",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "slackMessages.onCreate.sentAt",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "slackMessages.onCreate.retries",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "candidates",
       "queryScope": "COLLECTION",
       "fields": [

--- a/functions/actions/bugReports.js
+++ b/functions/actions/bugReports.js
@@ -1,10 +1,20 @@
-import { getDocuments } from '../shared/helpers.js';
+import config from '../shared/config.js';
+import { getDocument, getDocuments, applyUpdates } from '../shared/helpers.js';
 
-export default (db) => {
+export default (db, firebase) => {
   return {
+    getBugReportById,
     getBugReportByRef,
     getBugReportNumberFromIssueTitle,
+    incrementSlackRetries,
+    updateBugReportOnSlackSent,
+    getBugReportsWithFailedSendOnCreate,
+    updateBugReportOnCreate,
   };
+
+  async function getBugReportById(id) {
+    return await getDocument(db.collection('bugReports').doc(id));
+  }
 
   async function getBugReportByRef(referenceNumber) {
     const bugReportsRef = db.collection('bugReports').where('referenceNumber', '==', referenceNumber);
@@ -26,5 +36,104 @@ export default (db) => {
     const regex = /BR_\w+_\w+_(\d+)/;
     const match = issueTitle.match(regex);
     return match ? match[0] : match;
+  }
+
+  /**
+   * Get bugReports who have attempted to send at least one (but not the max number allowed) slack message 
+   * on creation of a github issue but failed
+   * @returns array
+   */
+  async function getBugReportsWithFailedSendOnCreate() {
+    try {
+      const MAX_RETRIES = config.SLACK_MAX_RETRIES ? config.SLACK_MAX_RETRIES : 3;
+      const bugReportsRef = db.collection('bugReports')
+        .where('slackMessages.onCreate.retries', '<', MAX_RETRIES)
+        .where('slackMessages.onCreate.sentAt', '==', null);
+      return await getDocuments(bugReportsRef);
+    } catch (error) {
+      console.error('Error fetching bug reports:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Update the num slack retries based on the action (eg create)
+   * This number specifies the number of times we've tried to send the slack msg to notify us that an issue was eg created
+   * @param {*} bugReport 
+   * @param {*} action 
+   * @returns 
+   */
+  async function incrementSlackRetries(bugReport, action = 'create') {
+    const commands = [];
+    if (action === 'create') {
+      const bugReportAction = 'onCreate';
+      let retries = bugReport.slackMessages[bugReportAction].retries;
+      const data = bugReport;
+      data.slackMessages.onCreate.retries = ++retries;
+      const MAX_RETRIES = config.SLACK_MAX_RETRIES ? config.SLACK_MAX_RETRIES : 3;
+      if (retries < MAX_RETRIES) {
+        commands.push({
+          command: 'update',
+          ref: bugReport.ref,
+          data: data,
+        });
+      }
+    }
+    if (commands.length) {
+      // write to db
+      const result = await applyUpdates(db, commands);
+      return result;
+    }
+    return true;
+  }
+
+  /**
+   * Update the slack retry timestamp based on the action (eg create)
+   * This timestamp specifies the time that the slack msg was sent when the issue was eg created
+   * @param {*} bugReport 
+   * @param {*} action 
+   * @returns 
+   */
+  async function updateBugReportOnSlackSent(bugReport, action = 'create') {
+    const commands = [];
+    if (action === 'create') {
+      const bugReportAction = 'onCreate';
+      const data = bugReport;
+      data.slackMessages.onCreate.sentAt = firebase.firestore.FieldValue.serverTimestamp();
+      commands.push({
+        command: 'update',
+        ref: bugReport.ref,
+        data: data,
+      });
+    }
+    if (commands.length) {
+      // write to db
+      const result = await applyUpdates(db, commands);
+      return result;
+    }
+    return true;
+  }
+
+  /**
+   * When a github issue is created update the bugReport with the issue number and url to the issue
+   * on github
+   * @param {*} bugReport 
+   * @param {*} issue 
+   * @returns 
+   */
+  async function updateBugReportOnCreate(bugReport, issueNumber, issueUrl) {
+    const commands = [];
+    commands.push({
+      command: 'update',
+      ref: bugReport.ref,
+      data: {
+        zenhubIssueNumber: issueNumber,
+        githubIssueUrl: issueUrl,
+        lastUpdatedAt: firebase.firestore.FieldValue.serverTimestamp(),
+      },
+    });
+    // write to db
+    const result = await applyUpdates(db, commands);
+    return result;
   }
 };

--- a/functions/actions/slack.js
+++ b/functions/actions/slack.js
@@ -1,12 +1,17 @@
 import initSlackWebApi from '../shared/slackWebApi.js';
 import initUsers from './users.js';
+import initBugReports from './bugReports.js';
+import initSendSlackNotifications from './zenhub/sendNewIssueSlackNotifications.js';
 
-export default (auth, config, db) => {
+export default (auth, config, db, firebase) => {
   const slackWebApi = initSlackWebApi(config);
   const { updateUser } = initUsers(auth, db);
+  const { getBugReportsWithFailedSendOnCreate } = initBugReports(db, firebase);
+  const { sendNewIssueSlackNotifications } = initSendSlackNotifications(config, db, auth, firebase);
 
   return {
     lookupSlackUser,
+    retrySlackMessageOnCreateIssue,
   };
 
   /**
@@ -23,5 +28,21 @@ export default (auth, config, db) => {
       });
     }
     return memberExists;
+  }
+
+  /**
+   * Check for slack messages which were not sent when the bugReport was created and resend them
+   * @param {*} slackChannelId 
+   * @returns 
+   */
+  async function retrySlackMessageOnCreateIssue(slackChannelId) {
+    const bugReports = await getBugReportsWithFailedSendOnCreate();
+    if (bugReports.length > 0) {
+      for (const bugReport of bugReports) {
+        const result = await sendNewIssueSlackNotifications(bugReport, slackChannelId);
+        return result;
+      }
+    }
+    return true;
   }
 };

--- a/functions/actions/zenhub/hooks/onAssignedIssue.js
+++ b/functions/actions/zenhub/hooks/onAssignedIssue.js
@@ -55,7 +55,7 @@ export default (config, db, auth) => {
     blocksArr.push(addSlackSection(issue, bugReport, assigneeUser, reporterUser));
 
     // Send Slack msg
-    slack.postBotBlocksMsgToChannel(slackChannelId, blocksArr);
+    await slack.postBotBlocksMsgToChannel(slackChannelId, blocksArr);
   }
 
   function addSlackDivider() {

--- a/functions/actions/zenhub/hooks/onCreatedIssue.js
+++ b/functions/actions/zenhub/hooks/onCreatedIssue.js
@@ -1,10 +1,8 @@
-import initSlack from '../../../shared/slack.js';
-import initUsers from '../../users.js';
+import initBugReports from '../../bugReports.js';
 
-export default (config, db, auth) => {
+export default (config, db, auth, firebase) => {
 
-  const slack = initSlack(config);
-  const { getUser } = initUsers(auth, db);
+  const { updateBugReportOnCreate } = initBugReports(db, firebase);
 
   return {
     onCreatedIssue,
@@ -12,94 +10,13 @@ export default (config, db, auth) => {
 
   /**
    * Hook called when an issue is created in github
-   * Send a message to a Slack channel notifying the team of the bug
+   * Add key details to the bug report from the issue
    * 
    * @param {object} params 
    * @param {object} bugReport
    * @param {string} slackChannelId
    */
-  async function onCreatedIssue(params, bugReport, slackChannelId) {
-
-    // @TODO: May be worth putting the reporter and userId fields into one object inside the bugReport collection record!?
-    const reporterUser = await getUser(bugReport.userId);
-
-    const issue = {
-      action: params.action,
-      url: params.issue.html_url,
-      id: params.issue.id,
-      number: params.issue.number,
-      title: params.issue.title,
-    };
-
-    // Build the slack message
-    const blocksArr = [];
-    blocksArr.push(addSlackDivider());
-    blocksArr.push(addSlackSection1(issue, bugReport, reporterUser));
-    blocksArr.push(addSlackSection2(bugReport));
-    if (bugReport.candidate) {
-      blocksArr.push(addSlackSection3(bugReport));
-    }
-
-    // Send Slack msg
-    slack.postBotBlocksMsgToChannel(slackChannelId, blocksArr);
-  }
-
-  function addSlackDivider() {
-    return {
-			'type': 'divider',
-		};
-  }
-  
-  function addSlackSection1(issue, data, user) {
-    let text = `The following *${data.criticality}* issue <${issue.url}|#${issue.number}> was raised by <@${user.slackMemberId}>`;
-    if (data.exercise.referenceNumber) {
-      text += ` for exercise: *${data.exercise.referenceNumber}*`;
-    }
-    else if (data.application.referenceNumber) {
-      text += ` for application: *${data.application.referenceNumber}*`;
-    }
-    return {
-      'type': 'section',
-      'text': {
-        'type': 'mrkdwn',
-        'text': text,
-      },
-    };
-  }
-
-  function addSlackSection2(data) {
-    return {
-      'type': 'section',
-      'text': {
-        'type': 'mrkdwn',
-        'text': `Description: ${data.issue}`,
-      },
-    };
-  }
-  
-  function addSlackSection3(data) {
-    let fields = [];
-    // fields.push(      {
-    //   'type': 'mrkdwn',
-    //   'text': `*Bug Reference Number:*\n${data.referenceNumber}`,
-    // });
-    //if (data.candidate) {
-    fields.push({
-      'type': 'mrkdwn',
-      'text': `*Candidate:*\n${data.candidate}`,
-    });
-    fields.push({
-      'type': 'mrkdwn',
-      'text': `*CPS Device:*\n${data.cpsDevice === '1' ? 'true' : 'false'}`,
-    });
-    //}
-    // fields.push(      {
-    //   'type': 'mrkdwn',
-    //   'text': `*Link to page:*\n<${data.url}>`,
-    // });
-    return {
-      'type': 'section',
-      'fields': fields,
-    };
+  async function onCreatedIssue(bugReport, issueNumber, issueUrl) {
+    await updateBugReportOnCreate(bugReport, issueNumber, issueUrl);
   }
 };

--- a/functions/actions/zenhub/sendNewIssueSlackNotifications.js
+++ b/functions/actions/zenhub/sendNewIssueSlackNotifications.js
@@ -1,0 +1,123 @@
+import initSlack from '../../shared/slack.js';
+import initUsers from '../users.js';
+import initBugReports from '../bugReports.js';
+import get from 'lodash/get.js';
+
+export default (config, db, auth, firebase) => {
+
+  const slack = initSlack(config);
+  const { getUser } = initUsers(auth, db);
+  const { incrementSlackRetries, updateBugReportOnSlackSent } = initBugReports(db, firebase);
+
+  return {
+    sendNewIssueSlackNotifications,
+  };
+
+  /**
+   * Called for new issues (or those previously created whose slack messages weren't sent out)
+   * Send a message to a Slack channel notifying the team of the bug
+   * Increment retries then send a slack message and only if successful set the timestamp
+   * 
+   * @param {object} params 
+   * @param {object} bugReport
+   * @param {string} slackChannelId
+   */
+  async function sendNewIssueSlackNotifications(bugReport, slackChannelId) {
+    const reporterUser = await getUser(bugReport.userId);
+
+    // Build the slack message
+    const blocksArr = [];
+    blocksArr.push(addSlackDivider());
+    blocksArr.push(addSlackSection1(bugReport, reporterUser));
+    blocksArr.push(addSlackSection2(bugReport));
+    if (bugReport.candidate) {
+      blocksArr.push(addSlackSection3(bugReport));
+    }
+
+    // Increment bugReport retries
+    await incrementSlackRetries(bugReport, 'create');
+
+    // Send Slack msg
+    const slackResponse = await slack.postBotBlocksMsgToChannel(slackChannelId, blocksArr);
+    if (slackResponse && Object.prototype.hasOwnProperty.call(slackResponse, 'ok') && slackResponse.ok === true) {
+
+      // Update the slack timestamp for the 'create' action
+      await updateBugReportOnSlackSent(bugReport, 'create');
+      return true;
+    }
+    else {
+      console.log(`Slack request failed for bugReport: ${bugReport.referenceNumber}`);
+      return false;
+    }
+  }
+
+  function addSlackDivider() {
+    return {
+			'type': 'divider',
+		};
+  }
+  
+  //function addSlackSection1(data, user, issue = null) {
+  function addSlackSection1(data, user) {
+    let text = '';
+
+    const githubIssueUrl = get(data, 'githubIssueUrl', null);
+    const zenhubIssueNumber = get(data, 'zenhubIssueNumber', null);
+
+    if (githubIssueUrl && zenhubIssueNumber) {
+      text += `The following *${data.criticality}* issue <${githubIssueUrl}|#${zenhubIssueNumber}> was raised by <@${user.slackMemberId}>`;
+    }
+    else {
+      text += `An issue was raised by <@${user.slackMemberId}> but we are unable to include the ticket number`;
+    }
+    if (data.exercise.referenceNumber) {
+      text += ` for exercise: *${data.exercise.referenceNumber}*`;
+    }
+    else if (data.application.referenceNumber) {
+      text += ` for application: *${data.application.referenceNumber}*`;
+    }
+    return {
+      'type': 'section',
+      'text': {
+        'type': 'mrkdwn',
+        'text': text,
+      },
+    };
+  }
+
+  function addSlackSection2(data) {
+    return {
+      'type': 'section',
+      'text': {
+        'type': 'mrkdwn',
+        'text': `Description: ${data.issue}`,
+      },
+    };
+  }
+  
+  function addSlackSection3(data) {
+    let fields = [];
+    // fields.push(      {
+    //   'type': 'mrkdwn',
+    //   'text': `*Bug Reference Number:*\n${data.referenceNumber}`,
+    // });
+    //if (data.candidate) {
+    fields.push({
+      'type': 'mrkdwn',
+      'text': `*Candidate:*\n${data.candidate}`,
+    });
+    fields.push({
+      'type': 'mrkdwn',
+      'text': `*CPS Device:*\n${data.cpsDevice === '1' ? 'true' : 'false'}`,
+    });
+    //}
+    // fields.push(      {
+    //   'type': 'mrkdwn',
+    //   'text': `*Link to page:*\n<${data.url}>`,
+    // });
+    return {
+      'type': 'section',
+      'fields': fields,
+    };
+  }
+};

--- a/functions/callableFunctions/verifySlackUser.js
+++ b/functions/callableFunctions/verifySlackUser.js
@@ -1,13 +1,13 @@
 import functions from 'firebase-functions';
 import config from '../shared/config.js';
-import { db, auth } from '../shared/admin.js';
+import { db, auth, firebase } from '../shared/admin.js';
 import { objectHasNestedProperty } from '../shared/helpers.js';
 import { checkArguments } from '../shared/helpers.js';
 import initServiceSettings from '../shared/serviceSettings.js';
 import initSlack from '../actions/slack.js';
 
 const { checkFunctionEnabled } = initServiceSettings(db);
-const slack = initSlack(auth, config, db);
+const slack = initSlack(auth, config, db, firebase);
 
 export default functions.region('europe-west2').https.onCall(async (data, context) => {
   await checkFunctionEnabled();

--- a/functions/index.js
+++ b/functions/index.js
@@ -4,6 +4,7 @@ import backupAuthentication from './scheduledFunctions/backupAuthentication.js';
 import processNotifications from './scheduledFunctions/processNotifications.js';
 import scheduleScanAllFiles from './scheduledFunctions/scheduleScanAllFiles.js';
 import runScannerTest from './scheduledFunctions/runScannerTest.js';
+import retrySlackMessageOnCreateIssue from './scheduledFunctions/retrySlackMsgOnCreateIssue.js';
 
 // Background
 import onDelete from './backgroundFunctions/onDelete.js';
@@ -112,6 +113,7 @@ export {
   processNotifications,
   scheduleScanAllFiles,
   runScannerTest,
+  retrySlackMessageOnCreateIssue,
 
   // Background
   onDelete,

--- a/functions/scheduledFunctions/retrySlackMsgOnCreateIssue.js
+++ b/functions/scheduledFunctions/retrySlackMsgOnCreateIssue.js
@@ -1,0 +1,20 @@
+import config from '../shared/config.js';
+import functions from 'firebase-functions';
+import { auth, firebase, db } from '../shared/admin.js';
+import initSlackActions from '../actions/slack.js';
+const { retrySlackMessageOnCreateIssue } = initSlackActions(auth, config, db, firebase);
+const SCHEDULE = config.SLACK_RETRY_SCHEDULE ? config.SLACK_RETRY_SCHEDULE : 'every 2 minutes';
+
+export default functions
+  .region('europe-west2')
+  .pubsub
+  .schedule(SCHEDULE)
+  .timeZone('Europe/London')
+  .onRun(async () => {
+    if (Object.prototype.hasOwnProperty.call(config, 'SLACK_TICKETING_APP_CHANNEL_ID')) {
+      const result = await retrySlackMessageOnCreateIssue(config.SLACK_TICKETING_APP_CHANNEL_ID);
+      return result;
+    }
+    console.log('Cannot run scheduled task: retrySlackMessageOnCreateIssue due to missing SLACK_TICKETING_APP_CHANNEL_ID');
+    return false;
+  });

--- a/functions/shared/config.js
+++ b/functions/shared/config.js
@@ -13,6 +13,8 @@ const CONSTANTS = {
   GITHUB_PAT: functions.config().github.pat, // personal access token
   SLACK_TICKETING_APP_BOT_TOKEN: functions.config().slack.ticketing_app_bot_token,
   SLACK_TICKETING_APP_CHANNEL_ID: functions.config().slack.ticketing_app_channel_id,
+  SLACK_RETRY_SCHEDULE: functions.config().slack.retry_send_schedule,
+  SLACK_MAX_RETRIES: 3,
   SCANNER_TEST_SCHEDULE: functions.config().scan_service.test_schedule,
   APPLICATION: {
     STATUS: {

--- a/functions/shared/slack.js
+++ b/functions/shared/slack.js
@@ -49,7 +49,7 @@ export default (config) => {
       };
       const msgConfig = {
         headers: {
-          'Content-type': 'application/json',
+          'Content-Type': 'application/json; charset=UTF-8',
           'Authorization': `Bearer ${slackBotToken}`,
         },
       };
@@ -79,7 +79,7 @@ export default (config) => {
       };
       const msgConfig = {
         headers: {
-          'Content-type': 'application/json',
+          'Content-Type': 'application/json; charset=UTF-8',
           'Authorization': `Bearer ${slackBotToken}`,
         },
       };

--- a/nodeScripts/temp/addSlackUIDToUserProfile.js
+++ b/nodeScripts/temp/addSlackUIDToUserProfile.js
@@ -1,10 +1,10 @@
 'use strict';
 
-import { app, auth, db } from '../shared/admin.js';
+import { app, auth, db, firebase } from '../shared/admin.js';
 import config from '../shared/config.js';
 import initSlack from '../../functions/actions/slack.js';
 
-const slack = initSlack(auth, config, db);
+const slack = initSlack(auth, config, db, firebase);
 
 // Details for 'Drie Contractor'
 const appUserId = 'uq7S68mW3zTKd6duK9L94dIyu1B2';

--- a/nodeScripts/testSlack.js
+++ b/nodeScripts/testSlack.js
@@ -1,12 +1,63 @@
 'use strict';
 
-import config from './shared/config.js';
+import config from '../functions/shared/config.js';
 import initSlack from '../functions/shared/slack.js';
-
 const slack = initSlack(config);
 
 const main = async () => {
-  return slack.post('WS Test');
+  // TEST 1
+  const result = await slack.post('OJ Test');
+  console.log('RESULT:');
+  console.log(result);
+    
+  // TEST 2
+  // const referenceNumber = 'BR_ADMIN_DE_000242';
+  // const bugReport = await getBugReportByRef(referenceNumber);
+
+  // console.log('bugReport:');
+  // console.log(bugReport);
+
+  // await incrementSlackRetries(bugReport, 'create');
+  //await updateBugReportOnSlackSent(bugReport, 'create');
+
+  // TEST 3
+  // const bugReports = await getBugReportsWithFailedSendOnCreate();
+  // //console.log(bugReports);
+  // for (const bugReport of bugReports) {
+  //   console.log(`referenceNumber: ${bugReport.referenceNumber}`);
+  // }
+
+  // // TEST 4
+  // // @TODO: Load createIssue.json into a variable and pass it into onCreatedIssue(params, bugReport, slackChannelId)
+  // try {
+  //   const slackChannelId = 'C0611PVFM1V';
+  //   const referenceNumbers = ['BR_ADMIN_DE_000248'];
+  //   for (const referenceNumber of referenceNumbers) {
+  //     console.log('<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<');
+  //     console.log(`referenceNumber: ${referenceNumber}`);
+  //     const bugReport = await getBugReportByRef(referenceNumber);
+  //     //const result = await sendNewIssueSlackNotifications(bugReport, slackChannelId);
+  //     const result = await sendNewIssueSlackNotifications(bugReport, slackChannelId);
+  //     console.log('RESULT');
+  //     console.log(result);
+  //   }
+  // }
+  // catch (e) {
+  //   console.log('ERROR');
+  //   console.log(e);
+  // }
+
+  // TEST 5
+  // try {
+  //   const slackChannelId = 'C0611PVFM1V';
+  //   await retrySlackMessageOnCreateIssue(slackChannelId);
+  // }
+  // catch (e) {
+  //   console.log('ERROR');
+  //   console.log(e);
+  // }
+
+  return true;
 };
 
 main()


### PR DESCRIPTION
Occasionally the slack message doesnt get sent when the create issue github hook calls our backend.
This PR allows us to track whether this message was sent and, if not, retry sending the message several times (specified by a constant in the config).
Added a scheduled task which runs every 2 mins to look for bugReports which havent had a slack message sent. If it finds any it tries to send the slack message.
Also modified existing code to:
- ensure the github link to the issue and the issue number are stored in the bugReport
- no longer send the slack message when the 'create issue' hook is called and leave it to the scheduled task to pick it up and send it

Closes #1261  