### PR TITLE
Bugfix: Scanner test logs

### DIFF
--- a/functions/actions/malware-scanning/runScannerTest.js
+++ b/functions/actions/malware-scanning/runScannerTest.js
@@ -40,7 +40,7 @@ export default (config, firebase, db) => {
     await servicesRef.set({
       fileUpload: {
         enabled: testResults.clean && testResults.eicar,
-        logs: logs,
+        // logs: logs,
       },
     }, { merge: true });
 


### PR DESCRIPTION
Turns off logging of the scanner test, as it was causing the `settings/candidateSettings` document to grow indefinitely.