### PR TITLE
jac-uk/admin#2657 PSDQ applications status

### DIFF
--- a/functions/actions/tasks/taskHelpers.js
+++ b/functions/actions/tasks/taskHelpers.js
@@ -430,6 +430,7 @@ export default (config) => {
     if (!exercise) return status;
     if (type === TASK_TYPE.EMP_TIEBREAKER) return APPLICATION_STATUS.SECOND_STAGE_INVITED;  // TODO: remove this eventually: override entry status for EMP tie-breakers
     if (type === TASK_TYPE.SELECTION_DAY) return APPLICATION_STATUS.SHORTLISTING_PASSED;
+    if (type === TASK_TYPE.PRE_SELECTION_DAY_QUESTIONNAIRE) return APPLICATION_STATUS.SHORTLISTING_PASSED;
     const prevTaskType = previousTaskType(exercise, type);
     if (prevTaskType) {
       console.log('previousTaskType', prevTaskType);


### PR DESCRIPTION
PSDQ entry status for applications should always be 'Shortlisting passed'

Closes jac-uk/admin#2657 