### PR TITLE
Bugfix/include all candidates in merit list

### DIFF
--- a/functions/actions/tasks/taskHelpers.js
+++ b/functions/actions/tasks/taskHelpers.js
@@ -622,6 +622,8 @@ export default (config) => {
     let SJpercents = [];
     try {
       finalScores.forEach(item => {
+        // only candidates pass both CAT and SJT should be included in zScores
+        if (item.scoreSheet.qualifyingTest.CA.pass === false || item.scoreSheet.qualifyingTest.SJ.pass === false) return;
         CApercents.push(item.scoreSheet.qualifyingTest.CA.percent);
         SJpercents.push(item.scoreSheet.qualifyingTest.SJ.percent);
       });
@@ -630,12 +632,24 @@ export default (config) => {
       const CAstdev = calculateStandardDeviation(CApercents);
       const SJstdev = calculateStandardDeviation(SJpercents);
       finalScores.forEach(item => {
-        item.scoreSheet.qualifyingTest.CA.zScore = CAstdev ? (item.scoreSheet.qualifyingTest.CA.percent - CAmean) / CAstdev : 0;
-        item.scoreSheet.qualifyingTest.SJ.zScore = SJstdev ? (item.scoreSheet.qualifyingTest.SJ.percent - SJmean) / SJstdev : 0;
+        // only candidates pass both CAT and SJT should be included in zScores
+        const isFailed = item.scoreSheet.qualifyingTest.CA.pass === false || item.scoreSheet.qualifyingTest.SJ.pass === false;
+        if (!isFailed) {
+          item.scoreSheet.qualifyingTest.CA.zScore = CAstdev ? (item.scoreSheet.qualifyingTest.CA.percent - CAmean) / CAstdev : 0;
+          item.scoreSheet.qualifyingTest.SJ.zScore = SJstdev ? (item.scoreSheet.qualifyingTest.SJ.percent - SJmean) / SJstdev : 0;          
+        } else {
+          item.scoreSheet.qualifyingTest.CA.zScore = null;
+          item.scoreSheet.qualifyingTest.SJ.zScore = null;
+        }
       });
       finalScores.forEach(item => {
         let zScore = (0.4 * item.scoreSheet.qualifyingTest.CA.zScore) + (0.6 * item.scoreSheet.qualifyingTest.SJ.zScore);
-        zScore = parseFloat(zScore.toFixed(2));
+        /**
+         * If failed one of CAT or SJT, then it should fail in overall merit list task.
+         * To achieve this, if one of the tests fails, all the scores and z-scores should be null.
+         */
+        if (item.scoreSheet.qualifyingTest.CA.pass === false || item.scoreSheet.qualifyingTest.SJ.pass === false) zScore = null;
+        if (zScore !== null) zScore = parseFloat(zScore.toFixed(2));
         if (zScore === 0) zScore = 0;
         item.zScore = zScore;
         item.scoreSheet.qualifyingTest.zScore = zScore;

--- a/functions/actions/tasks/updateTask.js
+++ b/functions/actions/tasks/updateTask.js
@@ -6,7 +6,7 @@ import initFactories from '../../shared/factories.js';
 import initQts from '../../shared/qts.js';
 import { getOverride } from './meritListHelper.js';
 import { GRADES, GRADE_VALUES, markingScheme2ScoreSheet } from '../../shared/scoreSheetHelper.js';
-
+import _unionBy from 'lodash/unionBy.js';
 export default (config, firebase, db) => {
   const {
     taskStatuses,
@@ -565,18 +565,48 @@ export default (config, firebase, db) => {
     return result;
   }
 
-  async function getApplications(exercise, task) {
+  async function getApplications(exercise, task, checkApplicationEntryStatus = true) {
     const applicationsData = [];
     let applicationsRef = db.collection('applications')
       .where('exerciseId', '==', exercise.id)
-      .where('status', '==', 'applied');
-    if (task.applicationEntryStatus) {
+      .where('status', 'in', ['applied', 'withdrawn']);
+    if (checkApplicationEntryStatus && task.applicationEntryStatus) {
       applicationsRef = applicationsRef.where('_processing.status', '==', task.applicationEntryStatus);
       console.log('get applications with status', task.applicationEntryStatus);
     }
+
+    // exclude the applications withdrawn before QT
+    let withdrawnBeforeQT = [];
+    if (task.type === config.TASK_TYPE.CRITICAL_ANALYSIS || task.type === config.TASK_TYPE.SITUATIONAL_JUDGEMENT) {
+      let qtStartDate = null;
+      if (task.type === config.TASK_TYPE.CRITICAL_ANALYSIS) {
+        qtStartDate = exercise.criticalAnalysisTestDate;        ;
+      } else if (task.type === config.TASK_TYPE.SITUATIONAL_JUDGEMENT) {
+        qtStartDate = exercise.situationalJudgementTestDate;
+      }
+      if (qtStartDate) {
+        withdrawnBeforeQT = await getDocuments(
+          db.collection('applicationRecords')
+            .where('exercise.id', '==', exercise.id)
+            .where('statusLog.withdrawn', '<', qtStartDate)
+            .select('status', 'statusLog')
+        );
+      }
+    }
+
+    let isWithdrawnBeforeQT = {};
+    if (withdrawnBeforeQT) {
+      withdrawnBeforeQT.forEach(applicationRecord => {
+        isWithdrawnBeforeQT[applicationRecord.id] = true;
+      });
+    }
+
     const applications = await getDocuments(applicationsRef);
     if (!applications) return applicationsData;
     applications.forEach(application => {
+      // exclude the applications withdrawn before QT
+      if (isWithdrawnBeforeQT[application.id]) return;
+
       if (application.personalDetails) {
         applicationsData.push({
           id: application.id,
@@ -584,9 +614,11 @@ export default (config, firebase, db) => {
           email: application.personalDetails.email || '',
           fullName: application.personalDetails.fullName || '',
           adjustments: application.personalDetails.reasonableAdjustments || false,
+          status: application.status,
         });
       }
     });
+
     return applicationsData;
   }
 
@@ -812,15 +844,18 @@ export default (config, firebase, db) => {
     // construct finalScores
     const finalScores = [];
     task.applications.forEach(application => {
-      if (response.scores[application.id]) {
-        finalScores.push({
-          id: application.id,
-          ref: application.ref,
-          score: response.scores[application.id],
-          percent: 100 * (response.scores[application.id] / response.maxScore),
-        });
-      }
+      // include zero score or no score
+      const score = response.scores[application.id] !== undefined ? response.scores[application.id] : 0;
+      const percent = 100 * (score / response.maxScore);
+
+      finalScores.push({
+        id: application.id,
+        ref: application.ref,
+        score,
+        percent,
+      });
     });
+
     result.success = true;
     result.data.maxScore = response.maxScore;
     result.data.finalScores = finalScores;
@@ -900,7 +935,7 @@ export default (config, firebase, db) => {
    * @returns Result object of the form `{ success: Boolean, data: Object }`. If successful then `data` is to be stored in the `task` document
    */
   async function completeTask(exercise, task) {
-
+    console.log('completeTask', task.type);
     const result = {
       success: false,
       data: {},
@@ -917,7 +952,8 @@ export default (config, firebase, db) => {
     if (didNotParticipateStatus) outcomeStats[didNotParticipateStatus] = 0;
 
     // get applications still relevant to this task
-    const applications = await getApplications(exercise, task);
+    const applications = await getApplications(exercise, task, false);
+    console.log('completeTask applications', applications.length);
     const applicationIdMap = {};
     applications.forEach(application => applicationIdMap[application.id] = true);
 
@@ -975,48 +1011,82 @@ export default (config, firebase, db) => {
       });
     }
 
+    console.log('applications.length', applications.length);
+
     // check for qualifying test follow on task
     if (task.type === config.TASK_TYPE.CRITICAL_ANALYSIS || task.type === config.TASK_TYPE.SITUATIONAL_JUDGEMENT) {
       if (
         exercise.shortlistingMethods.indexOf('critical-analysis-qualifying-test') >= 0 && exercise.criticalAnalysisTestDate
         && exercise.shortlistingMethods.indexOf('situational-judgement-qualifying-test') >= 0 && exercise.situationalJudgementTestDate
       ) {
+
         // get the other QT task
         const otherTaskType = task.type === config.TASK_TYPE.CRITICAL_ANALYSIS ? config.TASK_TYPE.SITUATIONAL_JUDGEMENT : config.TASK_TYPE.CRITICAL_ANALYSIS;
         const otherTask = await getDocument(db.doc(`exercises/${exercise.id}/tasks/${otherTaskType}`));
+       
+        console.log('task.type', task.type);
+        console.log('otherTaskType', otherTaskType);
+        console.log('otherTask.status', otherTask.status);
+
         if (otherTask.status === config.TASK_STATUS.COMPLETED) {
           // create qualifying test task
           const finalScores = [];
-          const applications = [];
-          task.finalScores.filter(scoreData => applicationIdMap[scoreData.id]).forEach(scoreData => {
-            if (scoreData.pass) {
-              const otherTaskScoreData = otherTask.finalScores.find(otherScoreData => otherScoreData.id === scoreData.id);
-              if (otherTaskScoreData && otherTaskScoreData.pass) {
-                const CAData = task.type === config.TASK_TYPE.CRITICAL_ANALYSIS ? scoreData : otherTaskScoreData;
-                const SJData = task.type === config.TASK_TYPE.CRITICAL_ANALYSIS ? otherTaskScoreData : scoreData;
-                finalScores.push({
-                  id: scoreData.id,
-                  ref: scoreData.ref,
-                  score: CAData.score + SJData.score,
-                  scoreSheet: {
-                    qualifyingTest: {
-                      CA: {
-                        score: CAData.score,
-                        percent: CAData.percent,
-                      },
-                      SJ: {
-                        score: SJData.score,
-                        percent: SJData.percent,
-                      },
-                      score: CAData.score + SJData.score,
-                    },
+
+          // the merit list should contains all the applications, even the CAT or SJT scores missing
+          const idToCAScore = {};
+          const idToSJScore = {};
+          for (const scoreData of task.finalScores) {
+            if (task.type === config.TASK_TYPE.CRITICAL_ANALYSIS) {
+              idToCAScore[scoreData.id] = scoreData;
+            } else if (task.type === config.TASK_TYPE.SITUATIONAL_JUDGEMENT) {
+              idToSJScore[scoreData.id] = scoreData;
+            }
+          }
+          for (const scoreData of otherTask.finalScores) {
+            if (otherTask.type === config.TASK_TYPE.CRITICAL_ANALYSIS) {
+              idToCAScore[scoreData.id] = scoreData;
+            } else if (otherTask.type === config.TASK_TYPE.SITUATIONAL_JUDGEMENT) {
+              idToSJScore[scoreData.id] = scoreData;
+            }
+          }
+
+          // contains union of CAT and SJT applications
+          const overallQTApplications = _unionBy(task.applications, otherTask.applications, 'id');
+          for (const application of overallQTApplications) {
+            const failedScoreData = { score: 0, percent: 0, pass: false };
+            let CAData = idToCAScore[application.id] || failedScoreData;
+            let SJData = idToSJScore[application.id] || failedScoreData;
+            
+            /**
+             * If failed one of CAT or SJT, then it should fail in overall merit list task.
+             * To achieve this, if one of the tests fails, all the scores and z-scores should be 0.
+             */
+            let score = CAData.score + SJData.score;
+            if (!CAData.pass || !SJData.pass) score = 0;
+            
+            finalScores.push({
+              id: application.id,
+              ref: application.ref,
+              score,
+              scoreSheet: {
+                qualifyingTest: {
+                  CA: {
+                    score: CAData.score,
+                    percent: CAData.percent,
+                    pass: CAData.pass, // for frontend can know if is first test failed
                   },
-                });
-                const application = task.applications.find(application => application.id === scoreData.id);
-                if (application) {
-                  applications.push(application);
-                }
-              } else {
+                  SJ: {
+                    score: SJData.score,
+                    percent: SJData.percent,
+                    pass: SJData.pass, // for frontend can know if is first test failed
+                  },
+                  score: CAData.score + SJData.score,
+                },
+              },
+            });
+
+            // if not pass one of the tests then fail
+            if (!CAData.pass || !SJData.pass) {
                 // update application record status to failed first test
                 outcomeStats[failStatus] += 1;
                 const saveData = {};
@@ -1024,18 +1094,17 @@ export default (config, firebase, db) => {
                 saveData[`statusLog.${failStatus}`] = firebase.firestore.FieldValue.serverTimestamp(); // we still always log the status change
                 commands.push({
                   command: 'update',
-                  ref: db.collection('applicationRecords').doc(scoreData.id),
+                  ref: db.collection('applicationRecords').doc(application.id),
                   data: saveData,
                 });
-              }
             }
-          });
+          }
 
           const taskData = {
             _stats: {
               totalApplications: finalScores.length,
             },
-            applications: applications,
+            applications: overallQTApplications,
             scoreType: 'zScore',
             finalScores: includeZScores(finalScores),
             markingScheme: [

--- a/test/actions/tasks/taskHelpers/includeZScores.spec.js
+++ b/test/actions/tasks/taskHelpers/includeZScores.spec.js
@@ -1085,4 +1085,36 @@ describe('includeZScores(finalScores)', () => {
     });
   });
 
+  describe('zScore calculations: candidates fail any of CAT or SJT should not be calculated in any zScore (SJT, CAT and overall)', () => {
+    const sourceData = [
+      // Pass CAT, Pass SJT
+      { expectedZScore: -0.2, expectedCATZScore: 1, expectedSJTZScore: -1, scoreSheet: { qualifyingTest: {CA: { percent: 1, pass: true }, SJ: { percent: 0.6, pass: true} } } },
+      { expectedZScore: 0.2, expectedCATZScore: -1, expectedSJTZScore: 1, scoreSheet: { qualifyingTest: {CA: { percent: 0.6, pass: true }, SJ: { percent: 1, pass: true} } } },
+      // Pass CAT, Fail SJT
+      { expectedZScore: null, expectedCATZScore: null, expectedSJTZScore: null, scoreSheet: { qualifyingTest: {CA: { percent: 1, pass: true }, SJ: { percent: 0.1, pass: false} } } },
+      // Fail CAT, Pass SJT
+      { expectedZScore: null, expectedCATZScore: null, expectedSJTZScore: null, scoreSheet: { qualifyingTest: {CA: { percent: 0.1, pass: false }, SJ: { percent: 1, pass: true} } } },
+      // Fail CAT, Fail SJT
+      { expectedZScore: null, expectedCATZScore: null, expectedSJTZScore: null, scoreSheet: { qualifyingTest: {CA: { percent: 0.1, pass: false }, SJ: { percent: 0.1, pass: false } } } },
+    ];
+    const resultData = includeZScores(sourceData);
+    // console.log('resultData', JSON.stringify(resultData, null, 2));
+    it('calculated zScores match expected zScores', async () => {
+      resultData.forEach((resultItem, index) => {
+        if (index < 2) {
+          expect(resultItem.zScore).toBeCloseTo(resultItem.expectedZScore);
+          expect(resultItem.scoreSheet.qualifyingTest.zScore).toBeCloseTo(resultItem.expectedZScore);
+          expect(resultItem.scoreSheet.qualifyingTest.CA.zScore).toBeCloseTo(resultItem.expectedCATZScore);
+          expect(resultItem.scoreSheet.qualifyingTest.SJ.zScore).toBeCloseTo(resultItem.expectedSJTZScore);
+        } else {
+          expect(resultItem.zScore).toBe(resultItem.expectedZScore);
+          expect(resultItem.scoreSheet.qualifyingTest.zScore).toBe(resultItem.expectedZScore);
+          expect(resultItem.scoreSheet.qualifyingTest.CA.zScore).toBe(resultItem.expectedCATZScore);
+          expect(resultItem.scoreSheet.qualifyingTest.SJ.zScore).toBe(resultItem.expectedSJTZScore);
+        }
+
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
Back end of this PR: https://github.com/jac-uk/admin/pull/2690
- Add candidates not having score in QT response to `exercise/tasks/criticalAnalysis` and  `exercise/tasks/situationalJudgement`, those candidates will have 0 scores.
- Add all candidates to  `exercise/tasks/qualifyingTest`, those candidates will have 0 scores in overall QT merit list.
- Store application status in `exercise/tasks/qualifyingTest.applidations` for marking withdrawn candidates.

