### PR TITLE
Bugfix/Country field in handover report

### DIFF
--- a/functions/actions/exercises/generateHandoverReport.js
+++ b/functions/actions/exercises/generateHandoverReport.js
@@ -201,7 +201,7 @@ const formatPersonalDetails = (personalDetails) => {
     town: address && address.town ? address.town : null,
     county: address && address.county ? address.county : null,
     postcode: address && address.postcode ? address.postcode : null,
-    country: address.country ? address.country : lookup(personalDetails.citizenship), // check if country is in address, if not use citizenship
+    country: address && address.country ? address.country : lookup(personalDetails.citizenship), // check if country is in address, if not use citizenship
     citizenship: lookup(personalDetails.citizenship),
     phone: personalDetails.phone || null,
     mobile: personalDetails.mobile || null,


### PR DESCRIPTION
### What's included?
- Check if the `address` object exists before accessing the `country` property.

![image](https://github.com/user-attachments/assets/67c99e9a-bbdf-4510-bc63-86cfeb25b04b)