### PR TITLE
jac-uk/admin#2704 Bugfix: isScoreSheetComplete

### DIFF
--- a/functions/shared/scoreSheetHelper.js
+++ b/functions/shared/scoreSheetHelper.js
@@ -355,12 +355,12 @@ function isScoreSheetComplete(markingScheme, scoreSheet) {
   markingScheme.forEach(item => {
     if (item.type === MARKING_TYPE.GROUP.value) {
       item.children.forEach(child => {
-        if (!scoreSheet[item.ref][child.ref]) {
+        if ([null, undefined, ''].indexOf(scoreSheet[item.ref][child.ref]) >= 0) {
           isComplete = false;
         }
       });
     } else {
-      if (!scoreSheet[item.ref]) {
+      if ([null, undefined, ''].indexOf(scoreSheet[item.ref]) >= 0) {
         isComplete = false;
       }
     }


### PR DESCRIPTION
Closes jac-uk/admin#2704

Updates helper function `isScoreSheetComplete` to take account of 0s in scoresheet data. Previously we were performing a truthy check which 0 was failing and so leading to the scoresheet being classed as incomplete. 0 is valid score data and so should not lead to incorrect flagging as incomplete