### PR TITLE
jac-uk/admin#2707 New Permission: can view panellists

### DIFF
--- a/database/firestore.rules
+++ b/database/firestore.rules
@@ -119,6 +119,7 @@ service cloud.firestore {
 
       // Allow JAC to read and write
       allow read, write: if userIsAuthenticated() && userIsJAC() && hasPermission('pa1');
+      allow read: if userIsAuthenticated() && userIsJAC() && hasPermission('pa2');
     }
 
     match /meta/stats {

--- a/functions/shared/permissions.js
+++ b/functions/shared/permissions.js
@@ -162,7 +162,7 @@ const PERMISSIONS = {
         value: 'pa1',
       },
       canViewPanellists: {
-        label: 'Can view panellist data',
+        label: 'Can view panellists',
         value: 'pa2',
       },
     },

--- a/functions/shared/permissions.js
+++ b/functions/shared/permissions.js
@@ -161,6 +161,10 @@ const PERMISSIONS = {
         label: 'Can manage panellist data',
         value: 'pa1',
       },
+      canViewPanellists: {
+        label: 'Can view panellist data',
+        value: 'pa2',
+      },
     },
   },
   panels: {


### PR DESCRIPTION
Adds a new permission to allow SETs to view panellist data. The panellist permissions are now:

**Can manage panellist data**
Allows user to view the panellist database and add, edit and delete panellists

**Can view panellists**
Allows user to view panellist data but not manage it. For example the user will be able to view a dropdown of panellists when creating/editing Panels

Closes jac-uk/admin#2707