### PR TITLE
#1355 Custom Report Range Error Maximum call stack size exceeded

### DIFF
--- a/functions/actions/exercises/customReport.js
+++ b/functions/actions/exercises/customReport.js
@@ -5,30 +5,31 @@ import _ from 'lodash';
 export default (db) => {
 
   return {
-    customReport,
+    //customReport,
     getColumnUsage,
   };
 
-  async function customReport(params, context) {
+  // @TODO: This function can be moved to the frontend
+  // async function customReport(params, context) {
 
-    let reportRef = db.collection('customReports');
+  //   let reportRef = db.collection('customReports');
 
-    if(_.get(params, 'columns', null)) {
-      //save report
-      const report = {
-        name: params.name,
-        columns: params.columns,
-        whereClauses: params.whereClauses,
-        users: [context.auth.uid],
-      };
-      await reportRef.add(report);
-    }
+  //   if(_.get(params, 'columns', null)) {
+  //     //save report
+  //     const report = {
+  //       name: params.name,
+  //       columns: params.columns,
+  //       whereClauses: params.whereClauses,
+  //       users: [context.auth.uid],
+  //     };
+  //     await reportRef.add(report);
+  //   }
 
-    const reports = await getDocuments(reportRef.where('users', 'array-contains', context.auth.uid));
+  //   const reports = await getDocuments(reportRef.where('users', 'array-contains', context.auth.uid));
 
-    return reports;
+  //   return reports;
 
-  }
+  // }
 
   async function getColumnUsage(orderBy = null) {
     let reportRef = db.collection('customReports');

--- a/functions/index.js
+++ b/functions/index.js
@@ -70,7 +70,7 @@ import adminSetDefaultRole from './callableFunctions/adminSetDefaultRole.js';
 import adminDisableNewUser from './callableFunctions/adminDisableNewUser.js';
 import adminSyncUserRolePermissions from './callableFunctions/adminSyncUserRolePermissions.js';
 import deleteUsers from './callableFunctions/deleteUsers.js';
-import customReport from './callableFunctions/customReport.js';
+//import customReport from './callableFunctions/customReport.js';
 import refreshApplicationCounts from './callableFunctions/refreshApplicationCounts.js';
 import createTestApplications from './callableFunctions/createTestApplications.js';
 import deleteApplications from './callableFunctions/deleteApplications.js';
@@ -171,7 +171,7 @@ export {
   adminDisableNewUser,
   adminSyncUserRolePermissions,
   deleteUsers,
-  customReport,
+  //customReport,
   refreshApplicationCounts,
   createTestApplications,
   deleteApplications,


### PR DESCRIPTION
Removed the customReport callable function as its not needed currently and was causing RangeErrors. We may reintroduce it in the future so only commented it out for now.

**This is associated with admin PR: https://github.com/jac-uk/admin/pull/2715**

Closes #1355 