### PR TITLE
Bugfix: QT Merit List for ex234

### DIFF
--- a/functions/actions/tasks/updateTask.js
+++ b/functions/actions/tasks/updateTask.js
@@ -1061,6 +1061,14 @@ export default (firebase, db) => {
             let SJData = idToSJScore[application.id] || failedScoreData;
 
             /**
+             * Bugfix: some/withdrawn candidates do not have 'pass' field. This is breaking the firestore commands as we are trying to set a field to `undefined`
+             * TODO check this fix and remove/replace as it doesn't seem 'right'!
+             */
+            if (CAData.pass === undefined) CAData.pass = false;
+            if (SJData.pass === undefined) SJData.pass = false;
+            /** end bigfix */
+
+            /**
              * If failed one of CAT or SJT, then it should fail in overall merit list task.
              * To achieve this, if one of the tests fails, all the scores and z-scores should be 0.
              */

--- a/nodeScripts/updateTask.js
+++ b/nodeScripts/updateTask.js
@@ -7,8 +7,8 @@ const { updateTask } = initUpdateTask(firebase, db);
 
 const main = async () => {
   return updateTask({
-    exerciseId: 'ebz1bzduUEToY8oZzNC5',
-    type: 'selectionDay',
+    exerciseId: '5Koy4ZOXpVH2kfiCKNLi',
+    type: 'situationalJudgement',
   });
 };
 


### PR DESCRIPTION
This is work in progress.

There is a bug introduced in https://github.com/jac-uk/digital-platform/pull/1343

Some applications do not have `.pass` data for CAT or SJT which is causing a firestore update command to break (as we are trying to set a field to `undefined`).